### PR TITLE
feat: Add maybeOf helper to InheritedWidgets and refactor of()

### DIFF
--- a/lib/src/naked_radio.dart
+++ b/lib/src/naked_radio.dart
@@ -43,10 +43,10 @@ class NakedRadioGroup<T> extends StatefulWidget {
   });
 
   @override
-  State<NakedRadioGroup<T>> createState() => _NakedRadioGroupState<T>();
+  State<NakedRadioGroup<T>> createState() => NakedRadioGroupState<T>();
 }
 
-class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
+class NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
   // Set of registered radio buttons
   final Set<_NakedRadioState<T>> _radios = {};
 
@@ -122,7 +122,7 @@ class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
 
 /// Internal InheritedWidget that provides radio group state to child radio buttons.
 class NakedRadioGroupScope<T> extends InheritedWidget {
-  final _NakedRadioGroupState<T> state;
+  final NakedRadioGroupState<T> state;
   final T? groupValue;
 
   /// Creates a radio group scope.
@@ -135,8 +135,7 @@ class NakedRadioGroupScope<T> extends InheritedWidget {
 
   /// Allows radio buttons to access their parent group.
   static NakedRadioGroupScope<T> of<T>(BuildContext context) {
-    final group =
-        context.dependOnInheritedWidgetOfExactType<NakedRadioGroupScope<T>>();
+    final group = maybeOf<T>(context);
     if (group == null) {
       throw FlutterError(
         'NakedRadioButton must be used within a NakedRadioGroup.\n'
@@ -144,6 +143,12 @@ class NakedRadioGroupScope<T> extends InheritedWidget {
       );
     }
     return group;
+  }
+
+  /// Allows radio buttons to access their parent group without throwing an error.
+  static NakedRadioGroupScope<T>? maybeOf<T>(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<NakedRadioGroupScope<T>>();
   }
 
   @override
@@ -306,7 +311,7 @@ class _NakedRadioState<T> extends State<NakedRadio<T>> {
   };
 
   bool _getInterative(
-    _NakedRadioGroupState<T> group,
+    NakedRadioGroupState<T> group,
   ) =>
       widget.enabled && group.widget.enabled && group.widget.onChanged != null;
 

--- a/lib/src/naked_select.dart
+++ b/lib/src/naked_select.dart
@@ -367,9 +367,13 @@ class NakedSelectInherited<T> extends InheritedWidget {
   });
 
   /// Gets the nearest NakedSelectInherited ancestor of the given context.
+  static NakedSelectInherited<T>? maybeOf<T>(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<NakedSelectInherited<T>>();
+  }
+
   static NakedSelectInherited<T> of<T>(BuildContext context) {
-    final inherited =
-        context.dependOnInheritedWidgetOfExactType<NakedSelectInherited<T>>();
+    final inherited = maybeOf<T>(context);
     if (inherited == null) {
       throw StateError(
         'NakedSelectInherited<$T> not found in context.\n'


### PR DESCRIPTION
Introduced maybeOf static methods to NakedRadioGroupScope and NakedSelectInherited for safer context lookups without exceptions. Refactored of() methods to use maybeOf internally, improving error handling and consistency.