### PR TITLE
fix: Wrap MouseRegion only when text field is enabled

### DIFF
--- a/example/lib/api/naked_select.1.dart
+++ b/example/lib/api/naked_select.1.dart
@@ -123,7 +123,7 @@ class _AnimatedSelectExampleState extends State<AnimatedSelectExample>
                   borderRadius: BorderRadius.circular(12),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
+                      color: Colors.black.withValues(alpha: 0.1),
                       blurRadius: 8,
                       offset: const Offset(0, 4),
                     ),

--- a/example/lib/api/naked_select.2.dart
+++ b/example/lib/api/naked_select.2.dart
@@ -129,7 +129,7 @@ class _AnimatedMultiSelectExampleState extends State<AnimatedMultiSelectExample>
                   borderRadius: BorderRadius.circular(12),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
+                      color: Colors.black.withValues(alpha: 0.1),
                       blurRadius: 8,
                       offset: const Offset(0, 4),
                     ),

--- a/lib/naked_ui.dart
+++ b/lib/naked_ui.dart
@@ -1,5 +1,3 @@
-library naked;
-
 // Components
 export 'src/naked_widgets.dart';
 // Utilities

--- a/lib/src/naked_radio.dart
+++ b/lib/src/naked_radio.dart
@@ -43,10 +43,10 @@ class NakedRadioGroup<T> extends StatefulWidget {
   });
 
   @override
-  State<NakedRadioGroup<T>> createState() => _NakedRadioGroupState<T>();
+  State<NakedRadioGroup<T>> createState() => NakedRadioGroupState<T>();
 }
 
-class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
+class NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
   // Set of registered radio buttons
   final Set<_NakedRadioState<T>> _radios = {};
 
@@ -122,7 +122,7 @@ class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
 
 /// Internal InheritedWidget that provides radio group state to child radio buttons.
 class NakedRadioGroupScope<T> extends InheritedWidget {
-  final _NakedRadioGroupState<T> state;
+  final NakedRadioGroupState<T> state;
   final T? groupValue;
 
   /// Creates a radio group scope.
@@ -306,7 +306,7 @@ class _NakedRadioState<T> extends State<NakedRadio<T>> {
   };
 
   bool _getInterative(
-    _NakedRadioGroupState<T> group,
+    NakedRadioGroupState<T> group,
   ) =>
       widget.enabled && group.widget.enabled && group.widget.onChanged != null;
 

--- a/lib/src/naked_textfield.dart
+++ b/lib/src/naked_textfield.dart
@@ -807,15 +807,22 @@ class _NakedTextFieldState extends State<NakedTextField>
               }
               _requestKeyboard();
             },
-      child: MouseRegion(
-        cursor: SystemMouseCursors.text,
-        onEnter: (PointerEnterEvent event) => widget.onHoverState?.call(true),
-        onExit: (PointerExitEvent event) => widget.onHoverState?.call(false),
-        child: _selectionGestureDetectorBuilder.buildGestureDetector(
-          behavior: HitTestBehavior.translucent,
-          child: widget.builder(context, child),
-        ),
-      ),
+      child: widget.enabled
+          ? MouseRegion(
+              cursor: SystemMouseCursors.text,
+              onEnter: (PointerEnterEvent event) =>
+                  widget.onHoverState?.call(true),
+              onExit: (PointerExitEvent event) =>
+                  widget.onHoverState?.call(false),
+              child: _selectionGestureDetectorBuilder.buildGestureDetector(
+                behavior: HitTestBehavior.translucent,
+                child: widget.builder(context, child),
+              ),
+            )
+          : _selectionGestureDetectorBuilder.buildGestureDetector(
+              behavior: HitTestBehavior.translucent,
+              child: widget.builder(context, child),
+            ),
     );
   }
 }

--- a/lib/src/naked_textfield.dart
+++ b/lib/src/naked_textfield.dart
@@ -147,7 +147,8 @@ class NakedTextField extends StatefulWidget {
     this.contentInsertionConfiguration,
     this.clipBehavior = Clip.hardEdge,
     this.restorationId,
-    this.scribbleEnabled = true,
+    this.onPressUpOutside,
+    this.stylusHandwritingEnabled = true,
     this.enableIMEPersonalizedLearning = true,
     this.contextMenuBuilder,
     this.canRequestFocus = true,
@@ -158,26 +159,28 @@ class NakedTextField extends StatefulWidget {
     this.style,
     required this.builder,
     this.ignorePointers,
-  })  : assert(obscuringCharacter.length == 1),
-        smartDashesType = smartDashesType ??
-            (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
-        smartQuotesType = smartQuotesType ??
-            (obscureText ? SmartQuotesType.disabled : SmartQuotesType.enabled),
-        assert(maxLines == null || maxLines > 0),
-        assert(minLines == null || minLines > 0),
-        assert(
-          (maxLines == null) || (minLines == null) || (maxLines >= minLines),
-          "minLines can't be greater than maxLines",
-        ),
-        assert(
-          !expands || (maxLines == null && minLines == null),
-          'minLines and maxLines must be null when expands is true.',
-        ),
-        assert(
-          !obscureText || maxLines == 1,
-          'Obscured fields cannot be multiline.',
-        ),
-        assert(maxLength == null || maxLength > 0);
+  }) : assert(obscuringCharacter.length == 1),
+       smartDashesType =
+           smartDashesType ??
+           (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
+       smartQuotesType =
+           smartQuotesType ??
+           (obscureText ? SmartQuotesType.disabled : SmartQuotesType.enabled),
+       assert(maxLines == null || maxLines > 0),
+       assert(minLines == null || minLines > 0),
+       assert(
+         (maxLines == null) || (minLines == null) || (maxLines >= minLines),
+         "minLines can't be greater than maxLines",
+       ),
+       assert(
+         !expands || (maxLines == null && minLines == null),
+         'minLines and maxLines must be null when expands is true.',
+       ),
+       assert(
+         !obscureText || maxLines == 1,
+         'Obscured fields cannot be multiline.',
+       ),
+       assert(maxLength == null || maxLength > 0);
 
   /// The magnifier configuration to use for this text field.
   final TextMagnifierConfiguration? magnifierConfiguration;
@@ -315,9 +318,8 @@ class NakedTextField extends StatefulWidget {
   /// Called when a tap is detected outside of the field.
   final TapRegionCallback? onTapOutside;
 
-  // TODO: Implement this on the Next version of Flutter
   /// Called when a tap up is detected outside of the field.
-  // final TapRegionUpCallback? onPressUpOutside;
+  final TapRegionUpCallback? onPressUpOutside;
 
   /// Drag start behavior.
   final DragStartBehavior dragStartBehavior;
@@ -340,8 +342,7 @@ class NakedTextField extends StatefulWidget {
   /// Restoration ID for this widget.
   final String? restorationId;
 
-  /// Whether scribble is enabled.
-  final bool scribbleEnabled;
+  final bool stylusHandwritingEnabled;
 
   /// Whether to enable IME personalized learning.
   final bool enableIMEPersonalizedLearning;
@@ -426,9 +427,7 @@ class _NakedTextFieldState extends State<NakedTextField>
   void initState() {
     super.initState();
     _selectionGestureDetectorBuilder =
-        _TextFieldSelectionGestureDetectorBuilder(
-      state: this,
-    );
+        _TextFieldSelectionGestureDetectorBuilder(state: this);
     if (widget.controller == null) {
       _createLocalController();
     }
@@ -538,7 +537,7 @@ class _NakedTextFieldState extends State<NakedTextField>
     }
 
     if (cause == SelectionChangedCause.longPress ||
-        cause == SelectionChangedCause.scribble) {
+        cause == SelectionChangedCause.stylusHandwriting) {
       return true;
     }
 
@@ -633,7 +632,8 @@ class _NakedTextFieldState extends State<NakedTextField>
     assert(debugCheckHasDirectionality(context));
 
     final ThemeData theme = Theme.of(context);
-    final TextStyle style = widget.style ??
+    final TextStyle style =
+        widget.style ??
         TextStyle(
           color: widget.enabled ? Colors.black : Colors.grey,
           fontSize: 16.0,
@@ -661,7 +661,8 @@ class _NakedTextFieldState extends State<NakedTextField>
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        spellCheckConfiguration = widget.spellCheckConfiguration ??
+        spellCheckConfiguration =
+            widget.spellCheckConfiguration ??
             const SpellCheckConfiguration.disabled();
     }
 
@@ -739,6 +740,7 @@ class _NakedTextFieldState extends State<NakedTextField>
               textAlign: widget.textAlign,
               textDirection: widget.textDirection,
               autofocus: widget.autofocus,
+              onTapUpOutside: widget.onPressUpOutside,
               obscuringCharacter: widget.obscuringCharacter,
               obscureText: widget.obscureText,
               autocorrect: widget.autocorrect,
@@ -780,14 +782,15 @@ class _NakedTextFieldState extends State<NakedTextField>
               autofillClient: this,
               clipBehavior: widget.clipBehavior,
               restorationId: 'editable',
-              scribbleEnabled: widget.scribbleEnabled,
+              stylusHandwritingEnabled: widget.stylusHandwritingEnabled,
               enableIMEPersonalizedLearning:
                   widget.enableIMEPersonalizedLearning,
               contentInsertionConfiguration:
                   widget.contentInsertionConfiguration,
               contextMenuBuilder: widget.contextMenuBuilder,
               spellCheckConfiguration: spellCheckConfiguration,
-              magnifierConfiguration: widget.magnifierConfiguration ??
+              magnifierConfiguration:
+                  widget.magnifierConfiguration ??
                   TextMagnifier.adaptiveMagnifierConfiguration,
             ),
           ),
@@ -829,10 +832,10 @@ class _NakedTextFieldState extends State<NakedTextField>
 
 class _TextFieldSelectionGestureDetectorBuilder
     extends TextSelectionGestureDetectorBuilder {
-  _TextFieldSelectionGestureDetectorBuilder(
-      {required _NakedTextFieldState state})
-      : _state = state,
-        super(delegate: state);
+  _TextFieldSelectionGestureDetectorBuilder({
+    required _NakedTextFieldState state,
+  }) : _state = state,
+       super(delegate: state);
 
   final _NakedTextFieldState _state;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,39 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0 # Restore original lints version
+  flutter_lints: ^6.0.0
 
-# The following section is specific to Flutter packages.
 flutter:
   uses-material-design: true
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/test/src/naked_accordion_test.dart
+++ b/test/src/naked_accordion_test.dart
@@ -10,32 +10,29 @@ Widget builder(bool isExpanded, {required String text}) {
 
 void main() {
   group('Basic Functionality', () {
-    Widget buildAccordion({
-      List<String> initialExpandedValues = const [],
-    }) {
+    Widget buildAccordion({List<String> initialExpandedValues = const []}) {
       return NakedAccordion<String>(
         controller: NakedAccordionController(),
         initialExpandedValues: initialExpandedValues,
         children: [
           NakedAccordionItem<String>(
             value: 'item1',
-            trigger: (_, __, ___) => const Text('Trigger 1'),
+            trigger: (_, _, _) => const Text('Trigger 1'),
             child: const Text('Content 1'),
           ),
           NakedAccordionItem<String>(
             value: 'item2',
-            trigger: (_, __, ___) => const Text('Trigger 2'),
+            trigger: (_, _, _) => const Text('Trigger 2'),
             child: const Text('Content 2'),
           ),
         ],
       );
     }
 
-    testWidgets('renders triggers correctly when closed',
-        (WidgetTester tester) async {
-      await tester.pumpMaterialWidget(
-        buildAccordion(),
-      );
+    testWidgets('renders triggers correctly when closed', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpMaterialWidget(buildAccordion());
 
       expect(find.text('Trigger 1'), findsOneWidget);
       expect(find.text('Trigger 2'), findsOneWidget);
@@ -43,8 +40,9 @@ void main() {
       expect(find.text('Content 2'), findsNothing);
     });
 
-    testWidgets('initially expands items based on initialExpandedValues',
-        (WidgetTester tester) async {
+    testWidgets('initially expands items based on initialExpandedValues', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpMaterialWidget(
         buildAccordion(initialExpandedValues: const ['item1']),
       );
@@ -70,7 +68,7 @@ void main() {
         children: [
           NakedAccordionItem<String>(
             value: 'item1',
-            trigger: (_, __, ___) => const Text('Trigger 1'),
+            trigger: (_, _, _) => const Text('Trigger 1'),
             onFocusState: (focused) => focusState = focused,
             autoFocus: autoFocus,
             focusNode: focusNode,
@@ -84,13 +82,13 @@ void main() {
       focusState = false;
     });
 
-    testWidgets('onFocusState callback is triggered when focused',
-        (WidgetTester tester) async {
+    testWidgets('onFocusState callback is triggered when focused', (
+      WidgetTester tester,
+    ) async {
       final focusNode = FocusNode();
-      await tester.pumpMaterialWidget(buildFocusableAccordion(
-        focusNode: focusNode,
-        autoFocus: false,
-      ));
+      await tester.pumpMaterialWidget(
+        buildFocusableAccordion(focusNode: focusNode, autoFocus: false),
+      );
 
       // Focus the accordion item
       focusNode.requestFocus();
@@ -110,7 +108,7 @@ void main() {
           children: [
             NakedAccordionItem<String>(
               value: 'item1',
-              trigger: (_, __, ___) => const Text('Trigger 1'),
+              trigger: (_, _, _) => const Text('Trigger 1'),
               onFocusState: (focused) => focusState = focused,
               autoFocus: true,
               child: const Text('Content 1'),
@@ -159,8 +157,9 @@ void main() {
       );
     }
 
-    testWidgets('controller.open() expands an item',
-        (WidgetTester tester) async {
+    testWidgets('controller.open() expands an item', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpMaterialWidget(buildControlledAccordion());
 
       expect(find.text('Open 1'), findsOneWidget);
@@ -177,8 +176,9 @@ void main() {
       expect(find.text('Content 2'), findsNothing);
     });
 
-    testWidgets('controller.close() collapses an item',
-        (WidgetTester tester) async {
+    testWidgets('controller.close() collapses an item', (
+      WidgetTester tester,
+    ) async {
       controller.open('item1');
       await tester.pumpMaterialWidget(buildControlledAccordion());
 
@@ -192,8 +192,9 @@ void main() {
       expect(find.text('Content 1'), findsNothing);
     });
 
-    testWidgets('controller.toggle() toggles item expansion',
-        (WidgetTester tester) async {
+    testWidgets('controller.toggle() toggles item expansion', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpMaterialWidget(buildControlledAccordion());
 
       expect(find.text('Open 1'), findsOneWidget);
@@ -212,8 +213,9 @@ void main() {
       expect(find.text('Content 1'), findsNothing);
     });
 
-    testWidgets('controller respects min expanded items',
-        (WidgetTester tester) async {
+    testWidgets('controller respects min expanded items', (
+      WidgetTester tester,
+    ) async {
       controller = NakedAccordionController<String>(min: 1);
       controller.open('item1');
 
@@ -230,8 +232,9 @@ void main() {
       expect(find.text('Content 1'), findsOneWidget);
     });
 
-    testWidgets('controller respects max expanded items',
-        (WidgetTester tester) async {
+    testWidgets('controller respects max expanded items', (
+      WidgetTester tester,
+    ) async {
       controller = NakedAccordionController<String>(max: 1);
 
       await tester.pumpMaterialWidget(buildControlledAccordion());
@@ -254,8 +257,9 @@ void main() {
       expect(find.text('Content 2'), findsOneWidget);
     });
 
-    testWidgets('controller respects both min and max constraints',
-        (WidgetTester tester) async {
+    testWidgets('controller respects both min and max constraints', (
+      WidgetTester tester,
+    ) async {
       controller = NakedAccordionController<String>(min: 1, max: 1);
 
       await tester.pumpMaterialWidget(buildControlledAccordion());
@@ -288,8 +292,9 @@ void main() {
       expect(find.text('Content 2'), findsOneWidget);
     });
 
-    testWidgets('controller.clear() collapses all items',
-        (WidgetTester tester) async {
+    testWidgets('controller.clear() collapses all items', (
+      WidgetTester tester,
+    ) async {
       controller.open('item1');
       controller.open('item2');
 
@@ -309,8 +314,9 @@ void main() {
       expect(find.text('Content 2'), findsNothing);
     });
 
-    testWidgets('controller.openAll() expands multiple items',
-        (WidgetTester tester) async {
+    testWidgets('controller.openAll() expands multiple items', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpMaterialWidget(buildControlledAccordion());
 
       expect(find.text('Open 1'), findsOneWidget);


### PR DESCRIPTION
Updated the widget tree to include MouseRegion for hover effects only when the text field is enabled. This prevents hover interactions when the field is disabled, improving expected behavior.