### PR TITLE
Update NakedRadioGroup link in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -31,8 +31,8 @@
           "href": "/widget/menu"
         },
         {
-          "title": "NakedRadioGroup",
-          "href": "/widget/radio_group"
+          "title": "NakedRadio",
+          "href": "/widget/radio"
         },
         {
           "title": "NakedSelect",


### PR DESCRIPTION
## Description

Renamed 'NakedRadioGroup' to 'NakedRadio' and updated its href from '/widget/radio_group' to '/widget/radio' in the documentation configuration.