### PR TITLE
feat: expose StrutStyle to NakedTextField.

### DIFF
--- a/lib/src/naked_textfield.dart
+++ b/lib/src/naked_textfield.dart
@@ -174,6 +174,7 @@ class NakedTextField extends StatefulWidget {
     this.ignorePointers,
     this.semanticLabel,
     this.semanticHint,
+    this.strutStyle,
   }) : assert(obscuringCharacter.length == 1),
        smartDashesType =
            smartDashesType ??
@@ -340,6 +341,9 @@ class NakedTextField extends StatefulWidget {
 
   /// Text style override (else derives from [DefaultTextStyle]).
   final TextStyle? style;
+
+  /// Defines the strut
+  final StrutStyle? strutStyle;
 
   /// Whether to ignore pointers.
   final bool? ignorePointers;
@@ -723,6 +727,7 @@ class _NakedTextFieldState extends State<NakedTextField>
       smartQuotesType: widget.smartQuotesType,
       enableSuggestions: widget.enableSuggestions,
       style: baseStyle,
+      strutStyle: widget.strutStyle,
       cursorColor: p.cursorColor,
       backgroundCursorColor: _neutralBgCursor,
       textAlign: widget.textAlign,


### PR DESCRIPTION
## Description

StrutStyle should be expose for more customization when we have to deal with multiple language.

## Related Issues

*-*

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.