### PR TITLE
fix: state scope not in the Context

### DIFF
--- a/lib/naked_ui.dart
+++ b/lib/naked_ui.dart
@@ -1,4 +1,4 @@
 // Components
 export 'src/naked_widgets.dart';
 // Utilities
-export 'src/utilities/utilities.dart';
+export 'src/utilities/utilities.dart' hide NakedStateScopeBuilder;

--- a/lib/src/naked_accordion.dart
+++ b/lib/src/naked_accordion.dart
@@ -547,9 +547,10 @@ class _NakedAccordionState<T> extends State<NakedAccordion<T>>
                           canExpand: canExpand,
                         );
 
-                        return NakedStateScope(
+                        return NakedStateScopeBuilder(
                           value: accordionState,
-                          child: widget.builder(context, accordionState),
+                          builder: (context, accordionState, child) =>
+                              widget.builder(context, accordionState),
                         );
                       },
                     ),

--- a/lib/src/naked_button.dart
+++ b/lib/src/naked_button.dart
@@ -51,10 +51,7 @@ class NakedButton extends StatefulWidget {
     this.focusOnPress = false,
     this.tooltip,
     this.semanticLabel,
-  }) : assert(
-         child != null || builder != null,
-         'Either child or builder must be provided',
-       );
+  });
 
   final Widget? child;
   final VoidCallback? onPressed;
@@ -182,13 +179,6 @@ class _NakedButtonState extends State<NakedButton>
   Widget build(BuildContext context) {
     final buttonState = NakedButtonState(states: widgetStates);
 
-    final content = NakedStateScope(
-      value: buttonState,
-      child: widget.builder != null
-          ? widget.builder!(context, buttonState, widget.child)
-          : widget.child!,
-    );
-
     return NakedFocusableDetector(
       enabled: _isInteractive,
       autofocus: widget.autofocus,
@@ -245,7 +235,11 @@ class _NakedButtonState extends State<NakedButton>
 
           behavior: HitTestBehavior.opaque,
           excludeFromSemantics: true,
-          child: content,
+          child: NakedStateScopeBuilder(
+            value: buttonState,
+            child: widget.child,
+            builder: widget.builder,
+          ),
         ),
       ),
     );

--- a/lib/src/naked_checkbox.dart
+++ b/lib/src/naked_checkbox.dart
@@ -91,10 +91,6 @@ class NakedCheckbox extends StatefulWidget {
   }) : assert(
          (tristate || value != null),
          'Non-tristate checkbox must have a non-null value',
-       ),
-       assert(
-         child != null || builder != null,
-         'Either child or builder must be provided',
        );
 
   /// The visual representation of the checkbox.
@@ -182,18 +178,18 @@ class _NakedCheckboxState extends State<NakedCheckbox>
     widget.onChanged!(nextValue);
   }
 
-  Widget _buildContent(BuildContext context) {
+  Widget _buildContent() {
     final checkboxState = NakedCheckboxState(
       states: widgetStates,
       isChecked: widget.value,
       tristate: widget.tristate,
     );
 
-    final content = widget.builder != null
-        ? widget.builder!(context, checkboxState, widget.child)
-        : widget.child!;
-
-    return NakedStateScope(value: checkboxState, child: content);
+    return NakedStateScopeBuilder(
+      value: checkboxState,
+      child: widget.child,
+      builder: widget.builder,
+    );
   }
 
   MouseCursor get _effectiveCursor => widget._effectiveEnabled
@@ -265,7 +261,7 @@ class _NakedCheckboxState extends State<NakedCheckbox>
                 : null,
             behavior: HitTestBehavior.opaque,
             excludeFromSemantics: true,
-            child: _buildContent(context),
+            child: _buildContent(),
           ),
         ),
       ),

--- a/lib/src/naked_menu.dart
+++ b/lib/src/naked_menu.dart
@@ -227,10 +227,7 @@ class NakedMenu<T> extends StatefulWidget {
     this.closeOnClickOutside = true,
     this.triggerFocusNode,
     this.positioning = const OverlayPositionConfig(),
-  }) : assert(
-         child != null || builder != null,
-         'Either child or builder must be provided',
-       );
+  });
 
   /// Type alias for [NakedMenuItem] for cleaner API access.
   static final Item = NakedMenuItem.new;
@@ -341,11 +338,12 @@ class _NakedMenuState<T> extends State<NakedMenu<T>>
               states: buttonState.states,
               isOpen: _isOpen,
             );
-            final content = widget.builder != null
-                ? widget.builder!(context, menuState, child)
-                : child!;
 
-            return NakedStateScope(value: menuState, child: content);
+            return NakedStateScopeBuilder(
+              value: menuState,
+              child: widget.child,
+              builder: widget.builder,
+            );
           },
         ),
       ),

--- a/lib/src/naked_popover.dart
+++ b/lib/src/naked_popover.dart
@@ -164,17 +164,17 @@ class _NakedPopoverState extends State<NakedPopover> {
     return null;
   }
 
-  Widget _buildTrigger(BuildContext context, FocusNode returnNode) {
+  Widget _buildTrigger(FocusNode returnNode) {
     final popoverState = NakedPopoverState(
       states: _statesController.value,
       isOpen: _menuController.isOpen,
     );
 
-    final content = widget.builder != null
-        ? widget.builder!(context, popoverState, widget.child)
-        : (widget.child ?? const SizedBox.shrink());
-
-    final child = NakedStateScope(value: popoverState, child: content);
+    final child = NakedStateScopeBuilder(
+      value: popoverState,
+      child: widget.child ?? const SizedBox.shrink(),
+      builder: widget.builder,
+    );
 
     // Case A: We own the focus node (no Focus provided by the child).
     if (identical(returnNode, _internalTriggerNode)) {
@@ -251,7 +251,7 @@ class _NakedPopoverState extends State<NakedPopover> {
         );
       },
 
-      child: _buildTrigger(context, returnNode),
+      child: _buildTrigger(returnNode),
     );
   }
 }

--- a/lib/src/naked_radio.dart
+++ b/lib/src/naked_radio.dart
@@ -183,32 +183,6 @@ class _NakedRadioState<T> extends State<NakedRadio<T>>
           });
         }
 
-        if (widget.builder != null) {
-          final isSelected = registry.groupValue == widget.value;
-          final statesWithSelection = {
-            ...states,
-            if (isSelected) WidgetState.selected,
-          };
-          final radioStateTyped = NakedRadioState<T>(
-            states: statesWithSelection,
-            value: widget.value,
-          );
-
-          final content = widget.builder!(
-            context,
-            radioStateTyped,
-            widget.child,
-          );
-
-          // Ensure the area is hit-testable so RawRadio's GestureDetector
-          // can receive taps even if the built widget has no gesture handlers.
-          return HitTestableContainer(
-            child: NakedStateScope(value: radioStateTyped, child: content),
-          );
-        }
-
-        // Ensure the child area is hit-testable for taps.
-        // Even without builder, provide state to descendants
         final isSelected = registry.groupValue == widget.value;
         final statesWithSelection = {
           ...states,
@@ -219,8 +193,14 @@ class _NakedRadioState<T> extends State<NakedRadio<T>>
           value: widget.value,
         );
 
+        // Ensure the area is hit-testable so RawRadio's GestureDetector
+        // can receive taps even if the built widget has no gesture handlers.
         return HitTestableContainer(
-          child: NakedStateScope(value: radioStateTyped, child: widget.child!),
+          child: NakedStateScopeBuilder(
+            value: radioStateTyped,
+            child: widget.child,
+            builder: widget.builder,
+          ),
         );
       },
     );

--- a/lib/src/naked_select.dart
+++ b/lib/src/naked_select.dart
@@ -378,11 +378,12 @@ class _NakedSelectState<T> extends State<NakedSelect<T>>
                   isOpen: _isOpen,
                   value: _effectiveValue,
                 );
-                final content = widget.builder != null
-                    ? widget.builder!(context, selectState, child)
-                    : child!;
 
-                return NakedStateScope(value: selectState, child: content);
+                return NakedStateScopeBuilder(
+                  value: selectState,
+                  child: widget.child,
+                  builder: widget.builder,
+                );
               },
             ),
           ),

--- a/lib/src/naked_slider.dart
+++ b/lib/src/naked_slider.dart
@@ -382,7 +382,11 @@ class _NakedSliderState extends State<NakedSlider>
     );
 
     final content = widget.builder != null
-        ? widget.builder!(context, sliderState, widget.child)
+        ? Builder(
+            builder: (context) {
+              return widget.builder!(context, sliderState, widget.child);
+            },
+          )
         : widget.child!;
 
     final childGesture = GestureDetector(

--- a/lib/src/naked_tabs.dart
+++ b/lib/src/naked_tabs.dart
@@ -279,10 +279,7 @@ class NakedTab extends StatefulWidget {
     this.onPressChange,
     this.builder,
     this.semanticLabel,
-  }) : assert(
-         child != null || builder != null,
-         'Either child or builder must be provided',
-       );
+  });
 
   /// The tab trigger content when not using [builder].
   final Widget? child;
@@ -422,11 +419,11 @@ class _NakedTabState extends State<NakedTab>
 
     final tabState = NakedTabState(states: widgetStates, tabId: widget.tabId);
 
-    final content = widget.builder != null
-        ? widget.builder!(context, tabState, widget.child)
-        : widget.child!;
-
-    final wrappedContent = NakedStateScope(value: tabState, child: content);
+    final wrappedContent = NakedStateScopeBuilder(
+      value: tabState,
+      child: widget.child,
+      builder: widget.builder,
+    );
 
     return NakedFocusableDetector(
       enabled: _isEnabled,

--- a/lib/src/naked_toggle.dart
+++ b/lib/src/naked_toggle.dart
@@ -185,17 +185,17 @@ class _NakedToggleState extends State<NakedToggle>
     widget.onChanged?.call(!widget.value);
   }
 
-  Widget _buildContent(BuildContext context) {
+  Widget _buildContent() {
     final toggleState = NakedToggleState(
       states: widgetStates,
       isToggled: widget.value,
     );
 
-    final content = widget.builder != null
-        ? widget.builder!(context, toggleState, widget.child)
-        : widget.child!;
-
-    return NakedStateScope(value: toggleState, child: content);
+    return NakedStateScopeBuilder(
+      value: toggleState,
+      child: widget.child,
+      builder: widget.builder,
+    );
   }
 
   MouseCursor get _effectiveCursor => widget._effectiveEnabled
@@ -264,7 +264,7 @@ class _NakedToggleState extends State<NakedToggle>
               : null,
           behavior: HitTestBehavior.opaque,
           excludeFromSemantics: true,
-          child: _buildContent(context),
+          child: _buildContent(),
         ),
       ),
     );

--- a/lib/src/utilities/naked_state_scope.dart
+++ b/lib/src/utilities/naked_state_scope.dart
@@ -175,3 +175,30 @@ class _NakedStateScopeState<T extends NakedState>
     );
   }
 }
+
+@internal
+class NakedStateScopeBuilder<T extends NakedState> extends StatelessWidget {
+  const NakedStateScopeBuilder({
+    super.key,
+    required this.value,
+    this.child,
+    this.builder,
+  }) : assert(
+         child != null || builder != null,
+         'Either child or builder must be provided',
+       );
+
+  final T value;
+  final Widget? child;
+  final ValueWidgetBuilder<T>? builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedStateScope(
+      value: value,
+      child: builder != null
+          ? Builder(builder: (context) => builder!(context, value, child))
+          : child!,
+    );
+  }
+}


### PR DESCRIPTION
Replaces direct usage of NakedStateScope with the new NakedStateScopeBuilder across multiple components, simplifying builder logic and improving consistency. Removes redundant assertions for child or builder presence from widget constructors. Adds NakedStateScopeBuilder implementation to utilities.

## Description

*A clear and concise description of what this PR is changing. If you're modifying existing behavior, please describe the old behavior, the new behavior, and the motivation for the change.*

## Related Issues

*Link to any relevant issues that this PR addresses. For example: `Closes #456`.*

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [ ] I have updated or added relevant documentation (doc comments with `///`).
- [ ] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.