### PR TITLE
refactor: Simplify NakedTextFieldBuilder signature

### DIFF
--- a/lib/src/naked_textfield.dart
+++ b/lib/src/naked_textfield.dart
@@ -21,8 +21,12 @@ import 'utilities/naked_focusable_detector.dart';
 import 'utilities/naked_state_scope.dart';
 import 'utilities/state.dart';
 
-typedef NakedTextFieldBuilder<T extends NakedState> =
-    Widget Function(BuildContext context, T value, Widget editableText);
+typedef NakedTextFieldBuilder =
+    Widget Function(
+      BuildContext context,
+      NakedTextFieldState value,
+      Widget editableText,
+    );
 
 /// Immutable view passed to [NakedTextField.builder].
 class NakedTextFieldState extends NakedState {


### PR DESCRIPTION
## Summary
- Removes generic type parameter from `NakedTextFieldBuilder`
- Makes the builder explicitly use `NakedTextFieldState` instead of a generic type
- Simplifies the API and makes it more concrete and easier to understand

## Changes
The typedef has been updated from:
```dart
typedef NakedTextFieldBuilder<T extends NakedState> =
    Widget Function(BuildContext context, T value, Widget editableText);
```

To:
```dart
typedef NakedTextFieldBuilder =
    Widget Function(
      BuildContext context,
      NakedTextFieldState value,
      Widget editableText,
    );
```

## Rationale
The generic type parameter was unnecessary since `NakedTextField` only ever passes `NakedTextFieldState` to its builder. This change makes the API more straightforward and removes cognitive overhead for users of the library.