### PR TITLE
Add ARIA focus behavior docs and focus tests

### DIFF
--- a/packages/example/lib/api/naked_popover.0.dart
+++ b/packages/example/lib/api/naked_popover.0.dart
@@ -64,6 +64,7 @@ class MyApp extends StatelessWidget {
             ],
           ),
         ),
+        drawerEnableOpenDragGesture: true,
       ),
     );
   }
@@ -78,6 +79,7 @@ class PopoverExample extends StatefulWidget {
 
 class _PopoverExampleState extends State<PopoverExample> {
   final _controller = MenuController();
+  bool isFocused = false;
 
   @override
   Widget build(BuildContext context) {
@@ -93,7 +95,7 @@ class _PopoverExampleState extends State<PopoverExample> {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: const Color(0xFF3D3D3D),
+          color: isFocused ? Colors.red.shade300 : Color(0xFF3D3D3D),
           borderRadius: BorderRadius.circular(8),
         ),
         child: const Text(
@@ -114,7 +116,7 @@ class PopoverMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       constraints: const BoxConstraints(maxWidth: 280),
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
       decoration: BoxDecoration(
         color: Colors.grey.shade50,
         borderRadius: BorderRadius.circular(8),
@@ -137,9 +139,9 @@ class PopoverMenu extends StatelessWidget {
                 'Popover Content',
                 style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
               ),
-              GestureDetector(
-                onTap: controller.close,
-                child: const Icon(Icons.close, size: 16),
+              IconButton(
+                onPressed: controller.close,
+                icon: const Icon(Icons.close, size: 16),
               ),
             ],
           ),
@@ -152,22 +154,10 @@ class PopoverMenu extends StatelessWidget {
           const SizedBox(height: 4),
           Align(
             alignment: Alignment.centerRight,
-            child: GestureDetector(
-              onTap: controller.close,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 8,
-                ),
-                decoration: BoxDecoration(
-                  color: Colors.grey.shade200,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Text(
-                  'Next',
-                  style: TextStyle(color: Colors.grey.shade600),
-                ),
-              ),
+            child: TextButton(
+              autofocus: true,
+              onPressed: controller.close,
+              child: const Text('Next'),
             ),
           ),
         ],

--- a/packages/naked_ui/lib/src/naked_dialog.dart
+++ b/packages/naked_ui/lib/src/naked_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'utilities/intents.dart';
@@ -89,9 +90,12 @@ Future<T?> showNakedDialog<T>({
 /// When [modal] is true, blocks background content interaction and
 /// configures screen reader route semantics.
 ///
+/// Automatically focuses the first focusable descendant when mounted,
+/// following ARIA dialog focus behavior.
+///
 /// See also:
 /// - [showNakedDialog], the function that displays dialogs.
-class NakedDialog extends StatelessWidget {
+class NakedDialog extends StatefulWidget {
   const NakedDialog({
     super.key,
     required this.child,
@@ -115,19 +119,43 @@ class NakedDialog extends StatelessWidget {
   final bool excludeSemantics;
 
   @override
+  State<NakedDialog> createState() => _NakedDialogState();
+}
+
+class _NakedDialogState extends State<NakedDialog> {
+  @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _focusFirstFocusable();
+    });
+  }
+
+  void _focusFirstFocusable() {
+    if (!mounted) return;
+
+    final scope = FocusScope.of(context);
+    // Find the first focusable descendant and focus it
+    final firstFocusable = scope.traversalDescendants.firstOrNull;
+    if (firstFocusable != null && firstFocusable.canRequestFocus) {
+      firstFocusable.requestFocus();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    Widget dialog = excludeSemantics
-        ? child
+    Widget dialog = widget.excludeSemantics
+        ? widget.child
         : Semantics(
             container: true,
             explicitChildNodes: true,
-            scopesRoute: modal,
-            namesRoute: modal,
-            label: semanticLabel,
-            child: child,
+            scopesRoute: widget.modal,
+            namesRoute: widget.modal,
+            label: widget.semanticLabel,
+            child: widget.child,
           );
 
-    if (modal && !excludeSemantics) {
+    if (widget.modal && !widget.excludeSemantics) {
       dialog = BlockSemantics(child: dialog);
     }
 

--- a/packages/naked_ui/lib/src/naked_popover.dart
+++ b/packages/naked_ui/lib/src/naked_popover.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'utilities/intents.dart';
@@ -245,20 +246,7 @@ class _NakedPopoverState extends State<NakedPopover> {
           child: TapRegion(
             onTapOutside: (event) => _menuController.close(),
             groupId: info.tapRegionGroupId,
-            child: FocusTraversalGroup(
-              child: Shortcuts(
-                shortcuts: NakedIntentActions.menu.shortcuts,
-                child: Actions(
-                  actions: NakedIntentActions.menu.actions(
-                    onDismiss: () => _menuController.close(),
-                    onNextFocus: () => FocusScope.of(context).nextFocus(),
-                    onPreviousFocus: () =>
-                        FocusScope.of(context).previousFocus(),
-                  ),
-                  child: widget.popoverBuilder(context, info),
-                ),
-              ),
-            ),
+            child: FocusScope(child: widget.popoverBuilder(context, info)),
           ),
         );
       },

--- a/packages/naked_ui/lib/src/naked_textfield.dart
+++ b/packages/naked_ui/lib/src/naked_textfield.dart
@@ -17,7 +17,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'mixins/naked_mixins.dart';
-import 'utilities/naked_focusable_detector.dart';
 import 'utilities/naked_state_scope.dart';
 import 'utilities/state.dart';
 
@@ -795,6 +794,11 @@ class _NakedTextFieldState extends State<NakedTextField>
               multiline: (widget.maxLines ?? 1) > 1,
               maxValueLength: widget.maxLength,
               currentValueLength: controller.text.length,
+              onFocus:
+                  defaultTargetPlatform != TargetPlatform.iOS &&
+                      _effectiveFocusNode.canRequestFocus
+                  ? focusNode.requestFocus
+                  : null,
               label: widget.semanticLabel,
               value: widget.obscureText ? null : controller.text,
               hint: widget.semanticHint,
@@ -817,16 +821,10 @@ class _NakedTextFieldState extends State<NakedTextField>
           withSemantics(widget.builder!(context, value, child!)),
     );
 
-    final Widget composedWithFocusSemantics = NakedFocusableDetector(
-      enabled: widget.enabled,
-      includeSemantics: true,
-      child: content,
-    );
-
     final Widget detector = _selectionGestureDetectorBuilder
         .buildGestureDetector(
           behavior: HitTestBehavior.translucent,
-          child: composedWithFocusSemantics,
+          child: content,
         );
 
     final Widget maybeMouseRegion = widget.enabled

--- a/packages/naked_ui/test/focus/accordion_focus_test.dart
+++ b/packages/naked_ui/test/focus/accordion_focus_test.dart
@@ -1,0 +1,524 @@
+/// ARIA Focus Behavior Tests for NakedAccordion
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Moves focus between accordion headers (each header is a tab stop)
+/// - Enter/Space: Toggles the accordion panel open/closed
+/// - Arrow Down: (Optional) Moves focus to next accordion header
+/// - Arrow Up: (Optional) Moves focus to previous accordion header
+/// - Home: (Optional) Moves focus to first accordion header
+/// - End: (Optional) Moves focus to last accordion header
+///
+/// Focus Behavior:
+/// - Each accordion header/trigger is in the tab order
+/// - When a panel opens, focus stays on the trigger (does NOT auto-move into panel)
+/// - Content inside expanded panels is reachable via Tab
+///
+/// Notes:
+/// - If using optional arrow key navigation, treat headers as a composite widget with roving tabindex
+/// - Without arrow keys, each header is simply a normal tab stop
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedAccordion ARIA Focus Behavior', () {
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus between accordion headers', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+        final focusNodeAccordion1 = FocusNode(debugLabel: 'accordion1');
+        final focusNodeAccordion2 = FocusNode(debugLabel: 'accordion2');
+        final focusNodeAccordion3 = FocusNode(debugLabel: 'accordion3');
+        final controller = NakedAccordionController<String>();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              NakedAccordionGroup<String>(
+                controller: controller,
+                child: Column(
+                  children: [
+                    NakedAccordion<String>(
+                      value: 'item1',
+                      focusNode: focusNodeAccordion1,
+                      builder: (_, state) => const Text('Header 1'),
+                      child: const Text('Content 1'),
+                    ),
+                    NakedAccordion<String>(
+                      value: 'item2',
+                      focusNode: focusNodeAccordion2,
+                      builder: (_, state) => const Text('Header 2'),
+                      child: const Text('Content 2'),
+                    ),
+                    NakedAccordion<String>(
+                      value: 'item3',
+                      focusNode: focusNodeAccordion3,
+                      builder: (_, state) => const Text('Header 3'),
+                      child: const Text('Content 3'),
+                    ),
+                  ],
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should move to first accordion header
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isFalse);
+        expect(focusNodeAccordion1.hasFocus, isTrue);
+
+        // Tab should move to second accordion header
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeAccordion2.hasFocus, isTrue);
+
+        // Tab should move to third accordion header
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeAccordion3.hasFocus, isTrue);
+
+        // Tab should move to element after accordion
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeAfter.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        focusNodeAfter.dispose();
+        focusNodeAccordion1.dispose();
+        focusNodeAccordion2.dispose();
+        focusNodeAccordion3.dispose();
+        controller.dispose();
+      });
+
+      testWidgets('Each accordion header is an independent tab stop', (
+        WidgetTester tester,
+      ) async {
+        final controller = NakedAccordionController<String>();
+        final focusNode1 = FocusNode(debugLabel: 'header1');
+        final focusNode2 = FocusNode(debugLabel: 'header2');
+        final focusNode3 = FocusNode(debugLabel: 'header3');
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: Column(
+              children: [
+                NakedAccordion<String>(
+                  value: 'item1',
+                  focusNode: focusNode1,
+                  builder: (_, state) => const Text('Header 1'),
+                  child: const Text('Content 1'),
+                ),
+                NakedAccordion<String>(
+                  value: 'item2',
+                  focusNode: focusNode2,
+                  builder: (_, state) => const Text('Header 2'),
+                  child: const Text('Content 2'),
+                ),
+                NakedAccordion<String>(
+                  value: 'item3',
+                  focusNode: focusNode3,
+                  builder: (_, state) => const Text('Header 3'),
+                  child: const Text('Content 3'),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        // Focus first header
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to second header
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode2.hasFocus, isTrue);
+
+        // Tab to third header
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+        focusNode3.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Keyboard Activation', () {
+      testWidgets('Enter key toggles accordion panel', (
+        WidgetTester tester,
+      ) async {
+        final controller = NakedAccordionController<String>();
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: NakedAccordion<String>(
+              value: 'item1',
+              focusNode: focusNode,
+              autofocus: true,
+              builder: (_, state) => const Text('Header 1'),
+              child: const Text('Content 1'),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        // Initially closed
+        expect(controller.contains('item1'), isFalse);
+        expect(find.text('Content 1'), findsNothing);
+
+        // Enter should open
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        expect(controller.contains('item1'), isTrue);
+        expect(find.text('Content 1'), findsOneWidget);
+
+        // Enter again should close
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        expect(controller.contains('item1'), isFalse);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+
+      testWidgets('Space key toggles accordion panel', (
+        WidgetTester tester,
+      ) async {
+        final controller = NakedAccordionController<String>();
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: NakedAccordion<String>(
+              value: 'item1',
+              focusNode: focusNode,
+              autofocus: true,
+              builder: (_, state) => const Text('Header 1'),
+              child: const Text('Content 1'),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        // Initially closed
+        expect(controller.contains('item1'), isFalse);
+
+        // Space should open
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(controller.contains('item1'), isTrue);
+
+        // Space again should close
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(controller.contains('item1'), isFalse);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+
+      testWidgets('Focus stays on trigger when panel opens', (
+        WidgetTester tester,
+      ) async {
+        final controller = NakedAccordionController<String>();
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: NakedAccordion<String>(
+              value: 'item1',
+              focusNode: focusNode,
+              autofocus: true,
+              builder: (_, state) => const Text('Header 1'),
+              child: const TextField(),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        expect(focusNode.hasFocus, isTrue);
+
+        // Open the panel
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        // Focus should still be on the trigger, not moved to content
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Content Accessibility', () {
+      testWidgets('Content inside expanded panel is reachable via Tab', (
+        WidgetTester tester,
+      ) async {
+        final controller = NakedAccordionController<String>();
+        final headerFocusNode = FocusNode(debugLabel: 'header');
+        final contentFocusNode = FocusNode(debugLabel: 'content');
+
+        // Start with panel expanded
+        controller.open('item1');
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: NakedAccordion<String>(
+              value: 'item1',
+              focusNode: headerFocusNode,
+              builder: (_, state) => const Text('Header 1'),
+              child: TextField(focusNode: contentFocusNode),
+            ),
+          ),
+        );
+
+        // Focus the header
+        headerFocusNode.requestFocus();
+        await tester.pump();
+        expect(headerFocusNode.hasFocus, isTrue);
+
+        // Tab should move to content inside expanded panel
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(contentFocusNode.hasFocus, isTrue);
+
+        headerFocusNode.dispose();
+        contentFocusNode.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Disabled Accordion Behavior', () {
+      testWidgets(
+        'Disabled accordion header should NOT receive focus via Tab',
+        (WidgetTester tester) async {
+          final controller = NakedAccordionController<String>();
+          final focusNode1 = FocusNode(debugLabel: 'header1');
+          final focusNodeDisabled = FocusNode(debugLabel: 'disabled');
+          final focusNode3 = FocusNode(debugLabel: 'header3');
+
+          await tester.pumpMaterialWidget(
+            NakedAccordionGroup<String>(
+              controller: controller,
+              child: Column(
+                children: [
+                  NakedAccordion<String>(
+                    value: 'item1',
+                    focusNode: focusNode1,
+                    builder: (_, state) => const Text('Header 1'),
+                    child: const Text('Content 1'),
+                  ),
+                  NakedAccordion<String>(
+                    value: 'item2',
+                    focusNode: focusNodeDisabled,
+                    enabled: false,
+                    builder: (_, state) => const Text('Header 2 (disabled)'),
+                    child: const Text('Content 2'),
+                  ),
+                  NakedAccordion<String>(
+                    value: 'item3',
+                    focusNode: focusNode3,
+                    builder: (_, state) => const Text('Header 3'),
+                    child: const Text('Content 3'),
+                  ),
+                ],
+              ),
+            ),
+          );
+
+          // Focus first header
+          focusNode1.requestFocus();
+          await tester.pump();
+          expect(focusNode1.hasFocus, isTrue);
+
+          // Tab should skip disabled and go to third
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pump();
+          expect(focusNodeDisabled.hasFocus, isFalse);
+          expect(focusNode3.hasFocus, isTrue);
+
+          focusNode1.dispose();
+          focusNodeDisabled.dispose();
+          focusNode3.dispose();
+          controller.dispose();
+        },
+      );
+
+      testWidgets(
+        'Disabled accordion does not respond to keyboard activation',
+        (WidgetTester tester) async {
+          final controller = NakedAccordionController<String>();
+          final focusNode = FocusNode();
+
+          await tester.pumpMaterialWidget(
+            NakedAccordionGroup<String>(
+              controller: controller,
+              child: NakedAccordion<String>(
+                value: 'item1',
+                focusNode: focusNode,
+                enabled: false,
+                autofocus: true,
+                builder: (_, state) => const Text('Header 1'),
+                child: const Text('Content 1'),
+              ),
+            ),
+          );
+
+          await tester.pump();
+
+          // Initially closed
+          expect(controller.contains('item1'), isFalse);
+
+          // Enter should NOT open disabled accordion
+          await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+          await tester.pump();
+
+          expect(controller.contains('item1'), isFalse);
+
+          // Space should NOT open disabled accordion
+          await tester.sendKeyEvent(LogicalKeyboardKey.space);
+          await tester.pump();
+
+          expect(controller.contains('item1'), isFalse);
+
+          focusNode.dispose();
+          controller.dispose();
+        },
+      );
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when header gains focus', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final controller = NakedAccordionController<String>();
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: NakedAccordion<String>(
+              value: 'item1',
+              focusNode: focusNode,
+              onFocusChange: (focused) => focusState = focused,
+              builder: (_, state) => const Text('Header 1'),
+              child: const Text('Content 1'),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusState, isTrue);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+
+      testWidgets('onFocusChange is called when header loses focus', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final controller = NakedAccordionController<String>();
+        final focusNode1 = FocusNode();
+        final focusNode2 = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: Column(
+              children: [
+                NakedAccordion<String>(
+                  value: 'item1',
+                  focusNode: focusNode1,
+                  onFocusChange: (focused) => focusState = focused,
+                  builder: (_, state) => const Text('Header 1'),
+                  child: const Text('Content 1'),
+                ),
+                TextField(focusNode: focusNode2),
+              ],
+            ),
+          ),
+        );
+
+        // Gain focus
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusState, isTrue);
+
+        // Lose focus
+        focusNode2.requestFocus();
+        await tester.pump();
+        expect(focusState, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Autofocus', () {
+      testWidgets('Accordion header with autofocus receives initial focus', (
+        WidgetTester tester,
+      ) async {
+        final controller = NakedAccordionController<String>();
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedAccordionGroup<String>(
+            controller: controller,
+            child: NakedAccordion<String>(
+              value: 'item1',
+              focusNode: focusNode,
+              autofocus: true,
+              builder: (_, state) => const Text('Header 1'),
+              child: const Text('Content 1'),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/button_focus_test.dart
+++ b/packages/naked_ui/test/focus/button_focus_test.dart
@@ -1,0 +1,625 @@
+/// ARIA Focus Behavior Tests for NakedButton
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Button receives focus in natural tab order
+/// - Shift+Tab: Button loses focus to previous focusable element
+/// - Enter/Space: Activates the button
+/// - Disabled buttons should NOT receive focus
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedButton ARIA Focus Behavior', () {
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus to button in natural tab order', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeButton = FocusNode(debugLabel: 'button');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedButton(
+                focusNode: focusNodeButton,
+                onPressed: () {},
+                child: const Text('Button'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to next element (button)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeButton.hasFocus, isTrue);
+
+        // Tab to next element (after button)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeButton.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Shift+Tab moves focus to previous element', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeButton = FocusNode(debugLabel: 'button');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedButton(
+                focusNode: focusNodeButton,
+                onPressed: () {},
+                child: const Text('Button'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the last element
+        focusNode3.requestFocus();
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        // Shift+Tab to previous element (button)
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNodeButton.hasFocus, isTrue);
+
+        // Shift+Tab to previous element (before button)
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeButton.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Button is a single tab stop', (WidgetTester tester) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeButton = FocusNode(debugLabel: 'button');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedButton(
+                focusNode: focusNodeButton,
+                onPressed: () {},
+                // Complex child with multiple elements
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.star),
+                    Text('Star Button'),
+                    Icon(Icons.arrow_forward),
+                  ],
+                ),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+
+        // Tab once should focus the entire button (not individual child elements)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeButton.hasFocus, isTrue);
+
+        // Tab again should skip to next element, not stay in button children
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeButton.dispose();
+        focusNode3.dispose();
+      });
+    });
+
+    group('Disabled Button Focus Behavior', () {
+      testWidgets('Disabled button should NOT receive focus via Tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeDisabledButton = FocusNode(debugLabel: 'disabled');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedButton(
+                focusNode: focusNodeDisabledButton,
+                onPressed: () {},
+                enabled: false,
+                child: const Text('Disabled Button'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab should skip disabled button and go directly to next element
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          focusNodeDisabledButton.hasFocus,
+          isFalse,
+          reason: 'Disabled button should not receive focus',
+        );
+        expect(
+          focusNode3.hasFocus,
+          isTrue,
+          reason: 'Focus should skip to next enabled element',
+        );
+
+        focusNode1.dispose();
+        focusNodeDisabledButton.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets(
+        'Button with null onPressed should NOT receive focus via Tab',
+        (WidgetTester tester) async {
+          final focusNode1 = FocusNode(debugLabel: 'before');
+          final focusNodeNullButton = FocusNode(debugLabel: 'null onPressed');
+          final focusNode3 = FocusNode(debugLabel: 'after');
+
+          await tester.pumpMaterialWidget(
+            Column(
+              children: [
+                TextField(focusNode: focusNode1),
+                NakedButton(
+                  focusNode: focusNodeNullButton,
+                  onPressed: null, // Non-interactive
+                  child: const Text('Non-interactive Button'),
+                ),
+                TextField(focusNode: focusNode3),
+              ],
+            ),
+          );
+
+          // Focus the first element
+          focusNode1.requestFocus();
+          await tester.pump();
+
+          // Tab should skip button with null onPressed
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pump();
+          expect(
+            focusNodeNullButton.hasFocus,
+            isFalse,
+            reason: 'Button with null onPressed should not receive focus',
+          );
+          expect(focusNode3.hasFocus, isTrue);
+
+          focusNode1.dispose();
+          focusNodeNullButton.dispose();
+          focusNode3.dispose();
+        },
+      );
+
+      testWidgets(
+        'Disabled button does not respond to programmatic focus request',
+        (WidgetTester tester) async {
+          final focusNodeDisabledButton = FocusNode(debugLabel: 'disabled');
+
+          await tester.pumpMaterialWidget(
+            NakedButton(
+              focusNode: focusNodeDisabledButton,
+              onPressed: () {},
+              enabled: false,
+              child: const Text('Disabled Button'),
+            ),
+          );
+
+          // Attempt to focus programmatically
+          focusNodeDisabledButton.requestFocus();
+          await tester.pump();
+
+          // Should not be able to focus a disabled button
+          expect(
+            focusNodeDisabledButton.hasFocus,
+            isFalse,
+            reason: 'Disabled button should not receive programmatic focus',
+          );
+
+          focusNodeDisabledButton.dispose();
+        },
+      );
+    });
+
+    group('Keyboard Activation', () {
+      testWidgets('Enter key activates the button', (
+        WidgetTester tester,
+      ) async {
+        bool wasPressed = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            autofocus: true,
+            onPressed: () => wasPressed = true,
+            child: const Text('Enter Test'),
+          ),
+        );
+
+        await tester.pump(); // Allow autofocus to take effect
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(wasPressed, isFalse);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        expect(wasPressed, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Space key activates the button', (
+        WidgetTester tester,
+      ) async {
+        bool wasPressed = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            autofocus: true,
+            onPressed: () => wasPressed = true,
+            child: const Text('Space Test'),
+          ),
+        );
+
+        await tester.pump(); // Allow autofocus to take effect
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(wasPressed, isFalse);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(wasPressed, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Enter key does not activate disabled button', (
+        WidgetTester tester,
+      ) async {
+        bool wasPressed = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            autofocus: true,
+            onPressed: () => wasPressed = true,
+            enabled: false,
+            child: const Text('Disabled'),
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        expect(wasPressed, isFalse);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Space key does not activate disabled button', (
+        WidgetTester tester,
+      ) async {
+        bool wasPressed = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            autofocus: true,
+            onPressed: () => wasPressed = true,
+            enabled: false,
+            child: const Text('Disabled'),
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(wasPressed, isFalse);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when focus is gained', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            onPressed: () {},
+            onFocusChange: (focused) => focusState = focused,
+            child: const Text('Focus Test'),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusState, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('onFocusChange is called when focus is lost', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode1 = FocusNode();
+        final focusNode2 = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedButton(
+                focusNode: focusNode1,
+                onPressed: () {},
+                onFocusChange: (focused) => focusState = focused,
+                child: const Text('Button 1'),
+              ),
+              TextField(focusNode: focusNode2),
+            ],
+          ),
+        );
+
+        // Gain focus
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusState, isTrue);
+
+        // Lose focus
+        focusNode2.requestFocus();
+        await tester.pump();
+        expect(focusState, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+      });
+
+      testWidgets('NakedButtonState correctly reflects focused state', (
+        WidgetTester tester,
+      ) async {
+        NakedButtonState? capturedState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            onPressed: () {},
+            builder: (context, state, child) {
+              capturedState = state;
+              return child ?? const SizedBox();
+            },
+            child: const Text('State Test'),
+          ),
+        );
+
+        // Initially not focused
+        expect(capturedState?.isFocused, isFalse);
+
+        // Focus the button
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(capturedState?.isFocused, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Multiple Buttons Navigation', () {
+      testWidgets('Tab navigates through multiple buttons in order', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'button1');
+        final focusNode2 = FocusNode(debugLabel: 'button2');
+        final focusNode3 = FocusNode(debugLabel: 'button3');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedButton(
+                focusNode: focusNode1,
+                onPressed: () {},
+                child: const Text('Button 1'),
+              ),
+              NakedButton(
+                focusNode: focusNode2,
+                onPressed: () {},
+                child: const Text('Button 2'),
+              ),
+              NakedButton(
+                focusNode: focusNode3,
+                onPressed: () {},
+                child: const Text('Button 3'),
+              ),
+            ],
+          ),
+        );
+
+        // Focus first button
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to second
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode2.hasFocus, isTrue);
+
+        // Tab to third
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Tab skips disabled buttons in the middle', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'button1');
+        final focusNodeDisabled = FocusNode(debugLabel: 'disabled');
+        final focusNode3 = FocusNode(debugLabel: 'button3');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedButton(
+                focusNode: focusNode1,
+                onPressed: () {},
+                child: const Text('Button 1'),
+              ),
+              NakedButton(
+                focusNode: focusNodeDisabled,
+                onPressed: () {},
+                enabled: false,
+                child: const Text('Disabled Button'),
+              ),
+              NakedButton(
+                focusNode: focusNode3,
+                onPressed: () {},
+                child: const Text('Button 3'),
+              ),
+            ],
+          ),
+        );
+
+        // Focus first button
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab should skip disabled and go to third
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeDisabled.hasFocus, isFalse);
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeDisabled.dispose();
+        focusNode3.dispose();
+      });
+    });
+
+    group('Autofocus', () {
+      testWidgets('Button with autofocus receives initial focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedButton(
+            focusNode: focusNode,
+            autofocus: true,
+            onPressed: () {},
+            child: const Text('Autofocus Button'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Only first autofocus button receives focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode();
+        final focusNode2 = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedButton(
+                focusNode: focusNode1,
+                autofocus: true,
+                onPressed: () {},
+                child: const Text('First Autofocus'),
+              ),
+              NakedButton(
+                focusNode: focusNode2,
+                autofocus: true,
+                onPressed: () {},
+                child: const Text('Second Autofocus'),
+              ),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode1.hasFocus, isTrue);
+        expect(focusNode2.hasFocus, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/checkbox_focus_test.dart
+++ b/packages/naked_ui/test/focus/checkbox_focus_test.dart
@@ -1,0 +1,743 @@
+/// ARIA Focus Behavior Tests for NakedCheckbox
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Checkbox receives focus in natural tab order
+/// - Space: Toggles checked state
+/// - Each checkbox is an independent tab stop
+/// - Disabled checkboxes should NOT receive focus
+///
+/// States tested:
+/// - aria-checked="true" — checked
+/// - aria-checked="false" — unchecked
+/// - aria-checked="mixed" — indeterminate (for tri-state checkboxes)
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedCheckbox ARIA Focus Behavior', () {
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus to checkbox in natural tab order', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeCheckbox = FocusNode(debugLabel: 'checkbox');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedCheckbox(
+                focusNode: focusNodeCheckbox,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Checkbox'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to next element (checkbox)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeCheckbox.hasFocus, isTrue);
+
+        // Tab to next element (after checkbox)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeCheckbox.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Shift+Tab moves focus to previous element', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeCheckbox = FocusNode(debugLabel: 'checkbox');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedCheckbox(
+                focusNode: focusNodeCheckbox,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Checkbox'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the last element
+        focusNode3.requestFocus();
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        // Shift+Tab to previous element (checkbox)
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNodeCheckbox.hasFocus, isTrue);
+
+        // Shift+Tab to previous element (before checkbox)
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeCheckbox.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Each checkbox is an independent tab stop', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'checkbox1');
+        final focusNode2 = FocusNode(debugLabel: 'checkbox2');
+        final focusNode3 = FocusNode(debugLabel: 'checkbox3');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedCheckbox(
+                focusNode: focusNode1,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Checkbox 1'),
+              ),
+              NakedCheckbox(
+                focusNode: focusNode2,
+                value: true,
+                onChanged: (_) {},
+                child: const Text('Checkbox 2'),
+              ),
+              NakedCheckbox(
+                focusNode: focusNode3,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Checkbox 3'),
+              ),
+            ],
+          ),
+        );
+
+        // Focus first checkbox
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to second checkbox
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode2.hasFocus, isTrue);
+
+        // Tab to third checkbox
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+        focusNode3.dispose();
+      });
+    });
+
+    group('Disabled Checkbox Focus Behavior', () {
+      testWidgets(
+        'Disabled checkbox should NOT receive focus via Tab',
+        (WidgetTester tester) async {
+          final focusNode1 = FocusNode(debugLabel: 'before');
+          final focusNodeDisabledCheckbox = FocusNode(debugLabel: 'disabled');
+          final focusNode3 = FocusNode(debugLabel: 'after');
+
+          await tester.pumpMaterialWidget(
+            Column(
+              children: [
+                TextField(focusNode: focusNode1),
+                NakedCheckbox(
+                  focusNode: focusNodeDisabledCheckbox,
+                  value: false,
+                  onChanged: (_) {},
+                  enabled: false,
+                  child: const Text('Disabled Checkbox'),
+                ),
+                TextField(focusNode: focusNode3),
+              ],
+            ),
+          );
+
+          // Focus the first element
+          focusNode1.requestFocus();
+          await tester.pump();
+          expect(focusNode1.hasFocus, isTrue);
+
+          // Tab should skip disabled checkbox and go directly to next element
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pump();
+          expect(
+            focusNodeDisabledCheckbox.hasFocus,
+            isFalse,
+            reason: 'Disabled checkbox should not receive focus',
+          );
+          expect(
+            focusNode3.hasFocus,
+            isTrue,
+            reason: 'Focus should skip to next enabled element',
+          );
+
+          focusNode1.dispose();
+          focusNodeDisabledCheckbox.dispose();
+          focusNode3.dispose();
+        },
+      );
+
+      testWidgets(
+        'Checkbox with null onChanged should NOT receive focus via Tab',
+        (WidgetTester tester) async {
+          final focusNode1 = FocusNode(debugLabel: 'before');
+          final focusNodeNullCheckbox = FocusNode(debugLabel: 'null onChanged');
+          final focusNode3 = FocusNode(debugLabel: 'after');
+
+          await tester.pumpMaterialWidget(
+            Column(
+              children: [
+                TextField(focusNode: focusNode1),
+                NakedCheckbox(
+                  focusNode: focusNodeNullCheckbox,
+                  value: false,
+                  onChanged: null, // Non-interactive
+                  child: const Text('Non-interactive Checkbox'),
+                ),
+                TextField(focusNode: focusNode3),
+              ],
+            ),
+          );
+
+          // Focus the first element
+          focusNode1.requestFocus();
+          await tester.pump();
+
+          // Tab should skip checkbox with null onChanged
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pump();
+          expect(
+            focusNodeNullCheckbox.hasFocus,
+            isFalse,
+            reason: 'Checkbox with null onChanged should not receive focus',
+          );
+          expect(focusNode3.hasFocus, isTrue);
+
+          focusNode1.dispose();
+          focusNodeNullCheckbox.dispose();
+          focusNode3.dispose();
+        },
+      );
+
+      testWidgets(
+        'Disabled checkbox does not respond to programmatic focus request',
+        (WidgetTester tester) async {
+          final focusNodeDisabledCheckbox = FocusNode(debugLabel: 'disabled');
+
+          await tester.pumpMaterialWidget(
+            NakedCheckbox(
+              focusNode: focusNodeDisabledCheckbox,
+              value: false,
+              onChanged: (_) {},
+              enabled: false,
+              child: const Text('Disabled Checkbox'),
+            ),
+          );
+
+          // Attempt to focus programmatically
+          focusNodeDisabledCheckbox.requestFocus();
+          await tester.pump();
+
+          // Should not be able to focus a disabled checkbox
+          expect(
+            focusNodeDisabledCheckbox.hasFocus,
+            isFalse,
+            reason: 'Disabled checkbox should not receive programmatic focus',
+          );
+
+          focusNodeDisabledCheckbox.dispose();
+        },
+      );
+
+      testWidgets('Tab skips disabled checkboxes in a group', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'checkbox1');
+        final focusNodeDisabled = FocusNode(debugLabel: 'disabled');
+        final focusNode3 = FocusNode(debugLabel: 'checkbox3');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedCheckbox(
+                focusNode: focusNode1,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Checkbox 1'),
+              ),
+              NakedCheckbox(
+                focusNode: focusNodeDisabled,
+                value: false,
+                onChanged: (_) {},
+                enabled: false,
+                child: const Text('Disabled Checkbox'),
+              ),
+              NakedCheckbox(
+                focusNode: focusNode3,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Checkbox 3'),
+              ),
+            ],
+          ),
+        );
+
+        // Focus first checkbox
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab should skip disabled and go to third
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeDisabled.hasFocus, isFalse);
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeDisabled.dispose();
+        focusNode3.dispose();
+      });
+    });
+
+    group('Keyboard Activation - Space Key', () {
+      testWidgets('Space key toggles unchecked to checked', (
+        WidgetTester tester,
+      ) async {
+        bool? currentValue = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            child: const Text('Space Test'),
+          ),
+        );
+
+        await tester.pump(); // Allow autofocus to take effect
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(currentValue, isFalse);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(currentValue, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Space key toggles checked to unchecked', (
+        WidgetTester tester,
+      ) async {
+        bool? currentValue = true;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            child: const Text('Space Test'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(currentValue, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(currentValue, isFalse);
+
+        focusNode.dispose();
+      });
+
+      testWidgets(
+        'Space key does not toggle disabled checkbox',
+        (WidgetTester tester) async {
+          bool? currentValue = false;
+          final focusNode = FocusNode();
+
+          await tester.pumpMaterialWidget(
+            NakedCheckbox(
+              focusNode: focusNode,
+              autofocus: true,
+              value: currentValue,
+              onChanged: (value) => currentValue = value,
+              enabled: false,
+              child: const Text('Disabled'),
+            ),
+          );
+
+          await tester.pump();
+
+          await tester.sendKeyEvent(LogicalKeyboardKey.space);
+          await tester.pump();
+
+          expect(currentValue, isFalse, reason: 'Value should not change');
+
+          focusNode.dispose();
+        },
+      );
+
+      testWidgets('Enter key also toggles checkbox', (
+        WidgetTester tester,
+      ) async {
+        // Note: While ARIA spec says Space toggles checkbox,
+        // Enter is also commonly supported for better usability
+        bool? currentValue = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            child: const Text('Enter Test'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(currentValue, isFalse);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        expect(currentValue, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Tristate (Mixed) Behavior', () {
+      testWidgets('Space key cycles through tristate values', (
+        WidgetTester tester,
+      ) async {
+        bool? currentValue = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedCheckbox(
+                focusNode: focusNode,
+                autofocus: true,
+                value: currentValue,
+                tristate: true,
+                onChanged: (value) => setState(() => currentValue = value),
+                child: const Text('Tristate'),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+        expect(focusNode.hasFocus, isTrue);
+
+        // false -> true
+        expect(currentValue, isFalse);
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+        expect(currentValue, isTrue);
+
+        // true -> null (mixed)
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+        expect(currentValue, isNull);
+
+        // null -> false
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+        expect(currentValue, isFalse);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('NakedCheckboxState correctly reports isIntermediate', (
+        WidgetTester tester,
+      ) async {
+        NakedCheckboxState? capturedState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            value: null,
+            tristate: true,
+            onChanged: (_) {},
+            builder: (context, state, child) {
+              capturedState = state;
+              return child ?? const SizedBox();
+            },
+            child: const Text('Mixed State'),
+          ),
+        );
+
+        expect(capturedState?.isIntermediate, isTrue);
+        expect(capturedState?.isChecked, isNull);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when focus is gained', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            value: false,
+            onChanged: (_) {},
+            onFocusChange: (focused) => focusState = focused,
+            child: const Text('Focus Test'),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusState, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('onFocusChange is called when focus is lost', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode1 = FocusNode();
+        final focusNode2 = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedCheckbox(
+                focusNode: focusNode1,
+                value: false,
+                onChanged: (_) {},
+                onFocusChange: (focused) => focusState = focused,
+                child: const Text('Checkbox 1'),
+              ),
+              TextField(focusNode: focusNode2),
+            ],
+          ),
+        );
+
+        // Gain focus
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusState, isTrue);
+
+        // Lose focus
+        focusNode2.requestFocus();
+        await tester.pump();
+        expect(focusState, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+      });
+
+      testWidgets('NakedCheckboxState correctly reflects focused state', (
+        WidgetTester tester,
+      ) async {
+        NakedCheckboxState? capturedState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            value: false,
+            onChanged: (_) {},
+            builder: (context, state, child) {
+              capturedState = state;
+              return child ?? const SizedBox();
+            },
+            child: const Text('State Test'),
+          ),
+        );
+
+        // Initially not focused
+        expect(capturedState?.isFocused, isFalse);
+
+        // Focus the checkbox
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(capturedState?.isFocused, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Checked State Reporting', () {
+      testWidgets('NakedCheckboxState correctly reflects checked state', (
+        WidgetTester tester,
+      ) async {
+        NakedCheckboxState? capturedState;
+
+        // Test unchecked (false)
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            value: false,
+            onChanged: (_) {},
+            builder: (context, state, child) {
+              capturedState = state;
+              return child ?? const SizedBox();
+            },
+            child: const Text('Unchecked'),
+          ),
+        );
+
+        expect(capturedState?.isChecked, isFalse);
+
+        // Test checked (true)
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            value: true,
+            onChanged: (_) {},
+            builder: (context, state, child) {
+              capturedState = state;
+              return child ?? const SizedBox();
+            },
+            child: const Text('Checked'),
+          ),
+        );
+
+        expect(capturedState?.isChecked, isTrue);
+      });
+
+      testWidgets('NakedCheckboxState correctly reflects tristate values', (
+        WidgetTester tester,
+      ) async {
+        NakedCheckboxState? capturedState;
+
+        // Test mixed/indeterminate (null)
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            value: null,
+            tristate: true,
+            onChanged: (_) {},
+            builder: (context, state, child) {
+              capturedState = state;
+              return child ?? const SizedBox();
+            },
+            child: const Text('Mixed'),
+          ),
+        );
+
+        expect(capturedState?.isChecked, isNull);
+        expect(capturedState?.isIntermediate, isTrue);
+        expect(capturedState?.tristate, isTrue);
+      });
+    });
+
+    group('Autofocus', () {
+      testWidgets('Checkbox with autofocus receives initial focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedCheckbox(
+            focusNode: focusNode,
+            autofocus: true,
+            value: false,
+            onChanged: (_) {},
+            child: const Text('Autofocus Checkbox'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Only first autofocus checkbox receives focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode();
+        final focusNode2 = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedCheckbox(
+                focusNode: focusNode1,
+                autofocus: true,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('First Autofocus'),
+              ),
+              NakedCheckbox(
+                focusNode: focusNode2,
+                autofocus: true,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Second Autofocus'),
+              ),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode1.hasFocus, isTrue);
+        expect(focusNode2.hasFocus, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+      });
+    });
+  });
+}
+

--- a/packages/naked_ui/test/focus/dialog_focus_test.dart
+++ b/packages/naked_ui/test/focus/dialog_focus_test.dart
@@ -1,0 +1,306 @@
+/// ARIA Focus Behavior Tests for NakedDialog
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+///
+/// On Open:
+/// - Move focus into dialog: Focus should move to the first focusable element,
+///   OR a primary action button, OR the dialog title (`tabindex="-1"`) if content is lengthy
+/// - Trap focus: Tab/Shift+Tab must cycle within the dialog only
+/// - Disable background: Background content should be `aria-hidden="true"` and not receive focus
+///
+/// While Open:
+/// - Tab: Cycles forward through focusable elements in dialog
+/// - Shift+Tab: Cycles backward through focusable elements
+/// - Escape: Closes dialog (for dismissible dialogs)
+///
+/// On Close:
+/// - Return focus: Focus MUST return to the element that opened the dialog
+/// - Fallback: If trigger no longer exists, focus should go to a logical alternative
+///
+/// Focus Trap Implementation:
+/// - First focusable ← Shift+Tab ← Last focusable
+/// - Last focusable → Tab → First focusable
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedDialog ARIA Focus Behavior', () {
+    group('Focus on Open', () {
+      testWidgets('Focus moves into dialog when opened', (
+        WidgetTester tester,
+      ) async {
+        final triggerFocusNode = FocusNode(debugLabel: 'trigger');
+
+        await tester.pumpMaterialWidget(
+          Builder(
+            builder: (context) {
+              return NakedButton(
+                focusNode: triggerFocusNode,
+                onPressed: () {
+                  showNakedDialog(
+                    context: context,
+                    barrierColor: Colors.black54,
+                    builder: (context) => NakedDialog(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('Dialog Content'),
+                          NakedButton(
+                            autofocus: true,
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('Close'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Open Dialog'),
+              );
+            },
+          ),
+        );
+
+        // Focus trigger and open dialog
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+        expect(triggerFocusNode.hasFocus, isTrue);
+
+        await tester.tap(find.text('Open Dialog'));
+        await tester.pumpAndSettle();
+
+        // Dialog should be open
+        expect(find.text('Dialog Content'), findsOneWidget);
+
+        // Focus should have moved into the dialog (trigger loses focus)
+        expect(triggerFocusNode.hasFocus, isFalse);
+
+        triggerFocusNode.dispose();
+      });
+    });
+
+    group('Focus Trap', () {
+      testWidgets('Tab cycles through focusable elements in dialog', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'input1');
+        final focusNode2 = FocusNode(debugLabel: 'input2');
+        final focusNode3 = FocusNode(debugLabel: 'button');
+
+        await tester.pumpMaterialWidget(
+          Builder(
+            builder: (context) {
+              return NakedButton(
+                onPressed: () {
+                  showNakedDialog(
+                    context: context,
+                    barrierColor: Colors.black54,
+                    builder: (context) => NakedDialog(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Focus(child: SizedBox(), focusNode: focusNode1),
+                          Focus(child: SizedBox(), focusNode: focusNode2),
+                          NakedButton(
+                            focusNode: focusNode3,
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('Button'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Open Dialog'),
+              );
+            },
+          ),
+        );
+
+        // Open dialog
+        await tester.tap(find.text('Open Dialog'));
+        await tester.pumpAndSettle();
+
+        // First element should have focus
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to second
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode2.hasFocus, isTrue);
+
+        // Tab to third
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Shift+Tab cycles backward through dialog elements', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'input1');
+        final focusNode2 = FocusNode(debugLabel: 'input2');
+
+        await tester.pumpMaterialWidget(
+          Builder(
+            builder: (context) {
+              return NakedButton(
+                onPressed: () {
+                  showNakedDialog(
+                    context: context,
+                    barrierColor: Colors.black54,
+                    builder: (context) => NakedDialog(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Focus(focusNode: focusNode1, child: SizedBox()),
+                          Focus(focusNode: focusNode2, child: SizedBox()),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Open Dialog'),
+              );
+            },
+          ),
+        );
+
+        // Open dialog
+        await tester.tap(find.text('Open Dialog'));
+        await tester.pumpAndSettle();
+
+        // Request focus on second element
+        focusNode2.requestFocus();
+        await tester.pump();
+        expect(focusNode2.hasFocus, isTrue);
+
+        // Shift+Tab to first
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+        expect(focusNode2.hasFocus, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+      });
+    });
+
+    group('Escape Key', () {
+      testWidgets('Escape closes dismissible dialog', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpMaterialWidget(
+          Builder(
+            builder: (context) {
+              return NakedButton(
+                onPressed: () {
+                  showNakedDialog(
+                    context: context,
+                    barrierColor: Colors.black54,
+                    barrierDismissible: true,
+                    builder: (context) => NakedDialog(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('Dialog Content'),
+                          NakedButton(
+                            autofocus: true,
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('Close'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Open Dialog'),
+              );
+            },
+          ),
+        );
+
+        // Open dialog
+        await tester.tap(find.text('Open Dialog'));
+        await tester.pumpAndSettle();
+        expect(find.text('Dialog Content'), findsOneWidget);
+
+        // Escape should close dialog
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Dialog Content'), findsNothing);
+      });
+    });
+
+    group('Focus Return on Close', () {
+      testWidgets('Focus returns to trigger when dialog closes', (
+        WidgetTester tester,
+      ) async {
+        final triggerFocusNode = FocusNode(debugLabel: 'trigger');
+
+        await tester.pumpMaterialWidget(
+          Builder(
+            builder: (context) {
+              return NakedButton(
+                focusNode: triggerFocusNode,
+                onPressed: () {
+                  showNakedDialog(
+                    context: context,
+                    barrierColor: Colors.black54,
+                    builder: (context) => NakedDialog(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('Dialog Content'),
+                          NakedButton(
+                            autofocus: true,
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('Close'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Open Dialog'),
+              );
+            },
+          ),
+        );
+
+        // Focus trigger and open dialog
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        await tester.tap(find.text('Open Dialog'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Dialog Content'), findsOneWidget);
+
+        // Close dialog
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Dialog Content'), findsNothing);
+        // Focus should return to trigger
+        expect(triggerFocusNode.hasFocus, isTrue);
+
+        triggerFocusNode.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/menu_focus_test.dart
+++ b/packages/naked_ui/test/focus/menu_focus_test.dart
@@ -1,0 +1,422 @@
+/// ARIA Focus Behavior Tests for NakedMenu
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Click/Enter on Trigger: Opens menu, focus moves to **first menu item**
+/// - Arrow Down: Moves focus to next menu item
+/// - Arrow Up: Moves focus to previous menu item
+/// - Home: Moves focus to first menu item
+/// - End: Moves focus to last menu item
+/// - Enter/Space: Activates focused menu item
+/// - Escape: Closes menu, returns focus to trigger
+/// - Tab: Closes menu, moves focus to next focusable (or trigger)
+/// - Type-ahead: Typing characters moves focus to matching item
+///
+/// Focus Management:
+/// - Uses **roving `tabindex`** inside menu
+/// - Menu trigger is in tab order; menu items are NOT
+/// - Focus must be **trapped inside open menu**
+/// - On close, focus MUST return to the trigger element
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedMenu ARIA Focus Behavior', () {
+    group('Menu Trigger Focus', () {
+      testWidgets('Menu trigger receives focus via Tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final focusNodeMenuTrigger = FocusNode(debugLabel: 'menuTrigger');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+        final controller = MenuController();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              NakedMenu<String>(
+                controller: controller,
+                triggerFocusNode: focusNodeMenuTrigger,
+                builder: (context, state, child) => const Text('Menu Trigger'),
+                overlayBuilder: (context, info) => const Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    NakedMenuItem<String>(
+                      value: 'item1',
+                      child: Text('Item 1'),
+                    ),
+                    NakedMenuItem<String>(
+                      value: 'item2',
+                      child: Text('Item 2'),
+                    ),
+                  ],
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should move to menu trigger
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeMenuTrigger.hasFocus, isTrue);
+
+        // Tab again should move to element after menu
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeAfter.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        focusNodeMenuTrigger.dispose();
+        focusNodeAfter.dispose();
+      });
+    });
+
+    group('Opening Menu', () {
+      testWidgets('Enter on trigger opens menu', (WidgetTester tester) async {
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+                NakedMenuItem<String>(value: 'item2', child: Text('Item 2')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Menu should be closed initially
+        expect(find.text('Item 1'), findsNothing);
+
+        // Enter should open menu
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Item 1'), findsOneWidget);
+      });
+
+      testWidgets('Space on trigger opens menu', (WidgetTester tester) async {
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Menu should be closed initially
+        expect(find.text('Item 1'), findsNothing);
+
+        // Space should open menu
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Item 1'), findsOneWidget);
+      });
+    });
+
+    group('Closing Menu', () {
+      testWidgets('Escape closes menu and returns focus to trigger', (
+        WidgetTester tester,
+      ) async {
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open the menu
+        controller.open();
+        await tester.pumpAndSettle();
+        expect(find.text('Item 1'), findsOneWidget);
+
+        // Escape should close menu
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Item 1'), findsNothing);
+      });
+    });
+
+    group('Arrow Key Navigation', () {
+      testWidgets('Arrow Down moves focus to next menu item', (
+        WidgetTester tester,
+      ) async {
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+        String? selectedValue;
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            onSelected: (value) => selectedValue = value,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+                NakedMenuItem<String>(value: 'item2', child: Text('Item 2')),
+                NakedMenuItem<String>(value: 'item3', child: Text('Item 3')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open the menu
+        controller.open();
+        await tester.pumpAndSettle();
+
+        // Arrow Down should navigate through items
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        expect(selectedValue, 'item1');
+
+        controller.open();
+        await tester.pumpAndSettle();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        expect(selectedValue, 'item2');
+      });
+
+      testWidgets('Arrow Up moves focus to previous menu item', (
+        WidgetTester tester,
+      ) async {
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+                NakedMenuItem<String>(value: 'item2', child: Text('Item 2')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open the menu
+        controller.open();
+        await tester.pumpAndSettle();
+
+        // Navigate down then up
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+
+        // Items should still be visible
+        expect(find.text('Item 1'), findsOneWidget);
+        expect(find.text('Item 2'), findsOneWidget);
+      });
+    });
+
+    group('Menu Item Activation', () {
+      testWidgets('Enter activates focused menu item', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue;
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            onSelected: (value) => selectedValue = value,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+                NakedMenuItem<String>(value: 'item2', child: Text('Item 2')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open the menu
+        controller.open();
+        await tester.pumpAndSettle();
+
+        // Navigate to first item and activate
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        expect(selectedValue, 'item1');
+      });
+
+      testWidgets('Space activates focused menu item', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue;
+        final controller = MenuController();
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedMenu<String>(
+            controller: controller,
+            triggerFocusNode: triggerFocusNode,
+            onSelected: (value) => selectedValue = value,
+            builder: (context, state, child) => const Text('Menu Trigger'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedMenuItem<String>(value: 'item1', child: Text('Item 1')),
+                NakedMenuItem<String>(value: 'item2', child: Text('Item 2')),
+              ],
+            ),
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open the menu
+        controller.open();
+        await tester.pumpAndSettle();
+
+        // Navigate to item and activate with Space
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        expect(selectedValue, 'item1');
+      });
+    });
+
+    // group('Disabled Menu Item Behavior', () {
+    //   testWidgets('Disabled menu item is skipped in navigation', (
+    //     WidgetTester tester,
+    //   ) async {
+    //     final controller = MenuController();
+    //     final triggerFocusNode = FocusNode();
+    //     String? selectedValue;
+
+    //     await tester.pumpMaterialWidget(
+    //       NakedMenu<String>(
+    //         controller: controller,
+    //         onSelected: (value) => selectedValue = value,
+    //         triggerFocusNode: triggerFocusNode,
+    //         builder: (context, state, child) => const Text('Menu Trigger'),
+    //         overlayBuilder: (context, info) => const Column(
+    //           mainAxisSize: MainAxisSize.min,
+    //           children: [
+    //             NakedMenuItem<String>(
+    //               value: 'item1',
+    //               child: Text('Item 1'),
+    //               // enabled: false,
+    //             ),
+    //             NakedMenuItem<String>(value: 'item2', child: Text('Item 2')),
+    //           ],
+    //         ),
+    //       ),
+    //     );
+
+    //     // Focus the trigger first (required for keyboard navigation)
+    //     triggerFocusNode.requestFocus();
+    //     await tester.pump();
+
+    //     // Open the menu
+    //     controller.open();
+    //     await tester.pumpAndSettle();
+
+    //     // All items should be visible
+    //     expect(find.text('Item 1'), findsOneWidget);
+    //     expect(find.text('Item 2'), findsOneWidget);
+
+    //     // Navigate down - should skip disabled Item 1 and focus Item 2
+    //     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    //     await tester.pump();
+
+    //     // Activate the focused item
+    //     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    //     await tester.pumpAndSettle();
+
+    //     // Item 2 should be selected (disabled Item 1 was skipped)
+    //     expect(selectedValue, 'item2');
+    //   });
+    // });
+  });
+}

--- a/packages/naked_ui/test/focus/popover_focus_test.dart
+++ b/packages/naked_ui/test/focus/popover_focus_test.dart
@@ -1,0 +1,154 @@
+/// ARIA Focus Behavior Tests for NakedPopover
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+///
+/// Trigger Behavior:
+/// - Click/Enter/Space on trigger: Opens popover
+/// - Escape: Closes popover
+///
+/// Focus Management (depends on popover type):
+/// - **Non-modal (tooltip-like)**: Focus stays on trigger; popover content not in tab order
+/// - **Interactive popover**: Focus may move into popover; Tab navigates within
+///
+/// On Close:
+/// - Return focus to trigger element
+///
+/// Notes:
+/// - Unlike dialogs, popovers typically don't trap focus
+/// - Clicking outside usually closes the popover
+/// - Content should be accessible but not interrupt user flow
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedPopover ARIA Focus Behavior', () {
+    group('Closing Popover', () {
+      testWidgets('Escape closes popover', (WidgetTester tester) async {
+        final triggerFocusNode = FocusNode();
+        final controller = MenuController();
+
+        await tester.pumpMaterialWidget(
+          NakedPopover(
+            controller: controller,
+            popoverBuilder: (context, info) => const Text('Popover Content'),
+            child: const Text('Popover Trigger'),
+          ),
+        );
+
+        controller.open();
+        await tester.pump();
+        expect(find.text('Popover Content'), findsOneWidget);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pumpAndSettle();
+        expect(find.text('Popover Content'), findsNothing);
+
+        triggerFocusNode.dispose();
+      });
+    });
+
+    group('Interactive Popover Content', () {
+      testWidgets('Tab can navigate to focusable content in popover', (
+        WidgetTester tester,
+      ) async {
+        final triggerFocusNode = FocusNode(debugLabel: 'trigger');
+        final contentFocusNode = FocusNode(debugLabel: 'content');
+        final controller = MenuController();
+
+        await tester.pumpMaterialWidget(
+          NakedPopover(
+            controller: controller,
+            popoverBuilder: (context, info) => TextField(
+              focusNode: contentFocusNode,
+              decoration: const InputDecoration(labelText: 'Input'),
+            ),
+            child: const Text('Popover Trigger'),
+          ),
+        );
+
+        controller.open();
+        await tester.pumpAndSettle();
+
+        // Tab should move to content in popover
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(contentFocusNode.hasFocus, isTrue);
+
+        triggerFocusNode.dispose();
+        contentFocusNode.dispose();
+      });
+
+      testWidgets('Tab cycles focus within popover and does not escape', (
+        WidgetTester tester,
+      ) async {
+        final outsideFocusNode = FocusNode(debugLabel: 'outside');
+        final input1FocusNode = FocusNode(debugLabel: 'input1');
+        final input2FocusNode = FocusNode(debugLabel: 'input2');
+        final controller = MenuController();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedPopover(
+                controller: controller,
+                popoverBuilder: (context, info) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      focusNode: input1FocusNode,
+                      decoration: const InputDecoration(labelText: 'Input 1'),
+                    ),
+                    TextField(
+                      focusNode: input2FocusNode,
+                      decoration: const InputDecoration(labelText: 'Input 2'),
+                    ),
+                  ],
+                ),
+                child: const Text('Popover Trigger'),
+              ),
+              TextField(
+                focusNode: outsideFocusNode,
+                decoration: const InputDecoration(labelText: 'Outside Input'),
+              ),
+            ],
+          ),
+        );
+
+        // Open the popover
+        controller.open();
+        await tester.pumpAndSettle();
+
+        // Tab to first input in popover
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(input1FocusNode.hasFocus, isTrue);
+
+        // Tab to second input in popover
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(input2FocusNode.hasFocus, isTrue);
+
+        // Tab again - focus should cycle back within popover, not escape outside
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        // Focus should NOT have escaped to the outside element
+        expect(outsideFocusNode.hasFocus, isFalse);
+
+        // Focus should still be within the popover (cycled back to first input)
+        expect(input1FocusNode.hasFocus, isTrue);
+
+        outsideFocusNode.dispose();
+        input1FocusNode.dispose();
+        input2FocusNode.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/radio_focus_test.dart
+++ b/packages/naked_ui/test/focus/radio_focus_test.dart
@@ -1,0 +1,464 @@
+/// ARIA Focus Behavior Tests for NakedRadio
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Focus enters the radio group on the **checked** radio; if none checked, focus goes to **first** radio
+/// - Tab (exit): Focus leaves the entire radio group to next focusable element
+/// - Arrow Down/Right: Moves focus to next radio (and selects it)
+/// - Arrow Up/Left: Moves focus to previous radio (and selects it)
+/// - Space: Selects the focused radio (if not already selected)
+/// - Home: (Optional) Moves focus to first radio
+/// - End: (Optional) Moves focus to last radio
+///
+/// Focus Management:
+/// - Uses **roving `tabindex`** — only one radio has `tabindex="0"`
+/// - The entire group is ONE tab stop
+/// - Arrow keys wrap (optional, but recommended)
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedRadio ARIA Focus Behavior', () {
+    group('Tab Navigation - Single Tab Stop for Group', () {
+      testWidgets('Tab enters radio group on first radio when none selected', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final focusNodeRadio1 = FocusNode(debugLabel: 'radio1');
+        final focusNodeRadio2 = FocusNode(debugLabel: 'radio2');
+        final focusNodeRadio3 = FocusNode(debugLabel: 'radio3');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+
+        String? selectedValue;
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              RadioGroup<String>(
+                groupValue: selectedValue,
+                onChanged: (value) => selectedValue = value,
+                child: Column(
+                  children: [
+                    NakedRadio<String>(
+                      value: 'option1',
+                      focusNode: focusNodeRadio1,
+                      child: Text('Option 1'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option2',
+                      focusNode: focusNodeRadio2,
+                      child: Text('Option 2'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option3',
+                      focusNode: focusNodeRadio3,
+                      child: Text('Option 3'),
+                    ),
+                  ],
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should enter the radio group
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        // Focus should be within the radio group (first radio)
+        expect(focusNodeBefore.hasFocus, isFalse);
+        expect(focusNodeAfter.hasFocus, isFalse);
+        expect(focusNodeRadio1.hasFocus, isTrue);
+        expect(focusNodeRadio2.hasFocus, isFalse);
+        expect(focusNodeRadio3.hasFocus, isFalse);
+
+        focusNodeBefore.dispose();
+        focusNodeAfter.dispose();
+        focusNodeRadio1.dispose();
+        focusNodeRadio2.dispose();
+        focusNodeRadio3.dispose();
+      });
+
+      testWidgets('Tab exits radio group to next focusable element', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final focusNodeRadio1 = FocusNode(debugLabel: 'radio1');
+        final focusNodeRadio2 = FocusNode(debugLabel: 'radio2');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              RadioGroup<String>(
+                groupValue: 'option1',
+                onChanged: (_) {},
+                child: Column(
+                  children: [
+                    NakedRadio<String>(
+                      value: 'option1',
+                      autofocus: true,
+                      focusNode: focusNodeRadio1,
+                      child: Text('Option 1'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option2',
+                      focusNode: focusNodeRadio2,
+                      child: Text('Option 2'),
+                    ),
+                  ],
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        focusNodeRadio1.requestFocus();
+        await tester.pump();
+
+        expect(focusNodeBefore.hasFocus, isFalse);
+        expect(focusNodeRadio1.hasFocus, isTrue);
+        expect(focusNodeRadio2.hasFocus, isFalse);
+        expect(focusNodeAfter.hasFocus, isFalse);
+
+        // Tab should exit the radio group
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        expect(focusNodeBefore.hasFocus, isFalse);
+        expect(focusNodeRadio1.hasFocus, isFalse);
+        expect(focusNodeRadio2.hasFocus, isFalse);
+        expect(focusNodeAfter.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        focusNodeRadio1.dispose();
+        focusNodeRadio2.dispose();
+        focusNodeAfter.dispose();
+      });
+    });
+
+    group('Arrow Key Navigation', () {
+      testWidgets('Arrow Down moves focus to next radio', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue = 'option1';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return RadioGroup<String>(
+                groupValue: selectedValue,
+                onChanged: (value) => setState(() => selectedValue = value),
+                child: const Column(
+                  children: [
+                    NakedRadio<String>(
+                      value: 'option1',
+                      autofocus: true,
+                      child: Text('Option 1'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option2',
+                      child: Text('Option 2'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option3',
+                      child: Text('Option 3'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Down should move to next and select
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        expect(selectedValue, 'option2');
+      });
+
+      testWidgets('Arrow Up moves focus to previous radio', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue = 'option2';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return RadioGroup<String>(
+                groupValue: selectedValue,
+                onChanged: (value) => setState(() => selectedValue = value),
+                child: const Column(
+                  children: [
+                    NakedRadio<String>(
+                      value: 'option1',
+                      child: Text('Option 1'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option2',
+                      autofocus: true,
+                      child: Text('Option 2'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option3',
+                      child: Text('Option 3'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Up should move to previous and select
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+
+        expect(selectedValue, 'option1');
+      });
+
+      testWidgets('Arrow Right moves focus to next radio (horizontal)', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue = 'option1';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return RadioGroup<String>(
+                groupValue: selectedValue,
+                onChanged: (value) => setState(() => selectedValue = value),
+                child: const Row(
+                  children: [
+                    NakedRadio<String>(
+                      value: 'option1',
+                      autofocus: true,
+                      child: Text('Option 1'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option2',
+                      child: Text('Option 2'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Right should move to next and select
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        expect(selectedValue, 'option2');
+      });
+
+      testWidgets('Arrow Left moves focus to previous radio (horizontal)', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue = 'option2';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return RadioGroup<String>(
+                groupValue: selectedValue,
+                onChanged: (value) => setState(() => selectedValue = value),
+                child: const Row(
+                  children: [
+                    NakedRadio<String>(
+                      value: 'option1',
+                      child: Text('Option 1'),
+                    ),
+                    NakedRadio<String>(
+                      value: 'option2',
+                      autofocus: true,
+                      child: Text('Option 2'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Left should move to previous and select
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+
+        expect(selectedValue, 'option1');
+      });
+    });
+
+    group('Disabled Radio Behavior', () {
+      // TODO (tilucasoli): Disabled radio is skipped in navigation.
+      // testWidgets('Disabled radio is skipped in navigation', (
+      //   WidgetTester tester,
+      // ) async {
+      //   String? selectedValue = 'option1';
+      //
+      //   await tester.pumpMaterialWidget(
+      //     StatefulBuilder(
+      //       builder: (context, setState) {
+      //         return RadioGroup<String>(
+      //           groupValue: selectedValue,
+      //           onChanged: (value) => setState(() => selectedValue = value),
+      //           child: const Column(
+      //             children: [
+      //               NakedRadio<String>(
+      //                 value: 'option1',
+      //                 autofocus: true,
+      //                 child: Text('Option 1'),
+      //               ),
+      //               NakedRadio<String>(
+      //                 value: 'option2',
+      //                 enabled: false,
+      //                 child: Text('Option 2 (disabled)'),
+      //               ),
+      //               NakedRadio<String>(
+      //                 value: 'option3',
+      //                 child: Text('Option 3'),
+      //               ),
+      //             ],
+      //           ),
+      //         );
+      //       },
+      //     ),
+      //   );
+      //
+      //   await tester.pump();
+      //
+      //   // Arrow Down should skip disabled and go to option3
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      //   await tester.pump();
+      //
+      //   // Note: Behavior depends on implementation - disabled may be skipped
+      //   // or included but not selectable
+      //   expect(selectedValue, isNot('option2'));
+      // });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when radio gains focus', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+
+        await tester.pumpMaterialWidget(
+          RadioGroup<String>(
+            groupValue: 'option1',
+            onChanged: (_) {},
+            child: Column(
+              children: [
+                NakedRadio<String>(
+                  value: 'option1',
+                  autofocus: true,
+                  onFocusChange: (focused) => focusState = focused,
+                  child: const Text('Option 1'),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        await tester.pump();
+        expect(focusState, isTrue);
+      });
+
+      testWidgets('onFocusChange is called when radio loses focus', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          RadioGroup<String>(
+            groupValue: 'option1',
+            onChanged: (_) {},
+            child: Column(
+              children: [
+                NakedRadio<String>(
+                  value: 'option1',
+                  autofocus: true,
+                  onFocusChange: (focused) => focusState = focused,
+                  child: const Text('Option 1'),
+                ),
+                Focus(
+                  focusNode: focusNode,
+                  child: const Text('Other focusable'),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        await tester.pump();
+        expect(focusState, isTrue);
+
+        // Move focus away from the radio
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusState, isFalse);
+      });
+
+      testWidgets('NakedRadioState correctly reflects selected state', (
+        WidgetTester tester,
+      ) async {
+        NakedRadioState<String>? capturedState;
+
+        await tester.pumpMaterialWidget(
+          RadioGroup<String>(
+            groupValue: 'option1',
+            onChanged: (_) {},
+            child: Column(
+              children: [
+                NakedRadio<String>(
+                  value: 'option1',
+                  builder: (context, state, child) {
+                    capturedState = state;
+                    return child ?? const SizedBox();
+                  },
+                  child: const Text('Option 1'),
+                ),
+                const NakedRadio<String>(
+                  value: 'option2',
+                  child: Text('Option 2'),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        expect(capturedState?.isSelected, isTrue);
+        expect(capturedState?.value, 'option1');
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/select_focus_test.dart
+++ b/packages/naked_ui/test/focus/select_focus_test.dart
@@ -1,0 +1,399 @@
+/// ARIA Focus Behavior Tests for NakedSelect (Combobox)
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Combobox trigger/input receives focus
+/// - Enter/Space/Arrow Down: Opens dropdown, focus moves to selected option (or first)
+/// - Arrow Down (open): Moves focus to next option
+/// - Arrow Up (open): Moves focus to previous option
+/// - Home (open): Moves focus to first option
+/// - End (open): Moves focus to last option
+/// - Enter/Space (open): Selects focused option, closes dropdown
+/// - Escape: Closes dropdown without selecting, returns focus to trigger
+/// - Tab (open): Selects focused option, closes dropdown, moves to next element
+/// - Type-ahead: Filters or jumps to matching option
+///
+/// Focus Management Options:
+/// - **DOM Focus**: Focus actually moves to options in the listbox
+/// - **`aria-activedescendant`**: Focus stays on combobox; `aria-activedescendant` points to active option
+///
+/// Notes:
+/// - When dropdown closes, focus MUST return to trigger
+/// - Selected option should be announced to screen readers
+/// - For multi-select: Space toggles selection, maintains dropdown open
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedSelect ARIA Focus Behavior', () {
+    Widget buildSelect<T>({
+      T? selectedValue,
+      ValueChanged<T?>? onSelectedValueChanged,
+      bool enabled = true,
+      FocusNode? triggerFocusNode,
+    }) {
+      return Center(
+        child: NakedSelect<T>(
+          value: selectedValue,
+          onChanged: onSelectedValueChanged,
+          enabled: enabled,
+          triggerFocusNode: triggerFocusNode,
+          builder: (context, state, child) => const Text('Select option'),
+          overlayBuilder: (context, info) => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              NakedSelectOption<T>(
+                value: 'apple' as T,
+                child: const Text('Apple'),
+              ),
+              NakedSelectOption<T>(
+                value: 'banana' as T,
+                child: const Text('Banana'),
+              ),
+              NakedSelectOption<T>(
+                value: 'orange' as T,
+                child: const Text('Orange'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus to select trigger', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final focusNodeSelectTrigger = FocusNode(debugLabel: 'selectTrigger');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              buildSelect<String>(triggerFocusNode: focusNodeSelectTrigger),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should move to select trigger
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isFalse);
+        expect(focusNodeSelectTrigger.hasFocus, isTrue);
+
+        // Tab again should move to element after select
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeAfter.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        focusNodeSelectTrigger.dispose();
+        focusNodeAfter.dispose();
+      });
+    });
+
+    group('Opening Dropdown', () {
+      testWidgets('Enter opens dropdown', (WidgetTester tester) async {
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          buildSelect<String>(
+            triggerFocusNode: triggerFocusNode,
+            onSelectedValueChanged: (_) {},
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Dropdown should be closed initially
+        expect(find.text('Apple'), findsNothing);
+
+        // Enter should open dropdown
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Apple'), findsOneWidget);
+
+        triggerFocusNode.dispose();
+      });
+
+      testWidgets('Space opens dropdown', (WidgetTester tester) async {
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          buildSelect<String>(
+            triggerFocusNode: triggerFocusNode,
+            onSelectedValueChanged: (_) {},
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Dropdown should be closed initially
+        expect(find.text('Apple'), findsNothing);
+
+        // Space should open dropdown
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Apple'), findsOneWidget);
+
+        triggerFocusNode.dispose();
+      });
+      // TODO (tilucasoli): Arrow Down opens dropdown is not implemented.
+      // testWidgets('Arrow Down opens dropdown', (WidgetTester tester) async {
+      //   final triggerFocusNode = FocusNode();
+      //
+      //   await tester.pumpMaterialWidget(
+      //     buildSelect<String>(
+      //       triggerFocusNode: triggerFocusNode,
+      //       onSelectedValueChanged: (_) {},
+      //     ),
+      //   );
+      //
+      //   triggerFocusNode.requestFocus();
+      //   await tester.pump();
+      //
+      //   // Arrow Down should open dropdown
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      //   await tester.pumpAndSettle();
+      //
+      //   expect(find.text('Apple'), findsOneWidget);
+      //
+      //   triggerFocusNode.dispose();
+      // });
+    });
+
+    group('Closing Dropdown', () {
+      testWidgets('Escape closes dropdown without selecting', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue;
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          buildSelect<String>(
+            selectedValue: selectedValue,
+            triggerFocusNode: triggerFocusNode,
+            onSelectedValueChanged: (value) => selectedValue = value,
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open dropdown
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+        expect(find.text('Apple'), findsOneWidget);
+
+        // Escape should close without selecting
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Apple'), findsNothing);
+        expect(selectedValue, isNull);
+
+        triggerFocusNode.dispose();
+      });
+    });
+
+    group('Arrow Key Navigation', () {
+      // TODO: The tests inside this group should be rewritten using the FocusNode on the options
+      // testWidgets('Arrow Down navigates through options', (
+      //   WidgetTester tester,
+      // ) async {
+      //   String? selectedValue;
+      //   final triggerFocusNode = FocusNode();
+
+      //   await tester.pumpMaterialWidget(
+      //     buildSelect<String>(
+      //       triggerFocusNode: triggerFocusNode,
+      //       onSelectedValueChanged: (value) => selectedValue = value,
+      //     ),
+      //   );
+
+      //   triggerFocusNode.requestFocus();
+      //   await tester.pump();
+
+      //   // Open dropdown
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      //   await tester.pumpAndSettle();
+
+      //   // Arrow Down should navigate
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      //   await tester.pump();
+
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      //   await tester.pump();
+
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      //   await tester.pump();
+
+      //   // Options should still be visible
+      //   expect(find.text('Apple'), findsNothing);
+      //   expect(find.text('Banana'), findsNothing);
+      //   expect(find.text('Orange'), findsNothing);
+
+      //   expect(selectedValue, 'orange');
+
+      //   triggerFocusNode.dispose();
+      // });
+
+      // TODO (tilucasoli): Arrow Up navigates through options is not implemented.
+      // testWidgets('Arrow Up navigates through options', (
+      //   WidgetTester tester,
+      // ) async {
+      //   final triggerFocusNode = FocusNode();
+      //   String? selectedValue;
+      //
+      //   await tester.pumpMaterialWidget(
+      //     buildSelect<String>(
+      //       triggerFocusNode: triggerFocusNode,
+      //       onSelectedValueChanged: (value) => selectedValue = value,
+      //     ),
+      //   );
+      //
+      //   triggerFocusNode.requestFocus();
+      //   await tester.pump();
+      //
+      //   // Open dropdown
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      //   await tester.pumpAndSettle();
+      //
+      //   // Navigate down then up
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      //   await tester.pump();
+      //
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      //   await tester.pump();
+      //
+      //   await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      //   await tester.pump();
+      //
+      //   // Options should still be visible
+      //   expect(find.text('Apple'), findsNothing);
+      //   expect(find.text('Banana'), findsNothing);
+      //   expect(find.text('Orange'), findsNothing);
+      //
+      //   expect(selectedValue, 'apple');
+      //
+      //   triggerFocusNode.dispose();
+      // });
+    });
+
+    group('Option Selection', () {
+      testWidgets('Enter selects focused option and closes dropdown', (
+        WidgetTester tester,
+      ) async {
+        String? selectedValue;
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return buildSelect<String>(
+                selectedValue: selectedValue,
+                triggerFocusNode: triggerFocusNode,
+                onSelectedValueChanged: (value) =>
+                    setState(() => selectedValue = value),
+              );
+            },
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Open dropdown
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        // Navigate to an option
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        // Select with Enter
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        // Dropdown should be closed and value selected
+        expect(selectedValue, isNotNull);
+
+        triggerFocusNode.dispose();
+      });
+    });
+
+    group('Disabled Select Behavior', () {
+      testWidgets('Disabled select should NOT receive focus via Tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              buildSelect<String>(enabled: false),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab should skip disabled select
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Disabled select does not open on keyboard activation', (
+        WidgetTester tester,
+      ) async {
+        final triggerFocusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          buildSelect<String>(
+            enabled: false,
+            triggerFocusNode: triggerFocusNode,
+          ),
+        );
+
+        triggerFocusNode.requestFocus();
+        await tester.pump();
+
+        // Enter should NOT open disabled select
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Apple'), findsNothing);
+
+        triggerFocusNode.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/slider_focus_test.dart
+++ b/packages/naked_ui/test/focus/slider_focus_test.dart
@@ -1,0 +1,474 @@
+/// ARIA Focus Behavior Tests for NakedSlider
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Slider thumb receives focus
+/// - Arrow Right/Up: Increases value by one step
+/// - Arrow Left/Down: Decreases value by one step
+/// - Page Up: Increases value by larger step (e.g., 10%)
+/// - Page Down: Decreases value by larger step
+/// - Home: Sets value to minimum
+/// - End: Sets value to maximum
+///
+/// Required Attributes:
+/// - `aria-valuenow` — current value
+/// - `aria-valuemin` — minimum value
+/// - `aria-valuemax` — maximum value
+/// - `aria-valuetext` — (optional) human-readable value
+///
+/// Notes:
+/// - For range sliders with two thumbs, each thumb is a separate tab stop
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedSlider ARIA Focus Behavior', () {
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus to slider in natural tab order', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeSlider = FocusNode(debugLabel: 'slider');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedSlider(
+                focusNode: focusNodeSlider,
+                value: 0.5,
+                onChanged: (_) {},
+                child: const SizedBox(width: 200, height: 40),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to next element (slider)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeSlider.hasFocus, isTrue);
+
+        // Tab to next element (after slider)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeSlider.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Shift+Tab moves focus to previous element', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeSlider = FocusNode(debugLabel: 'slider');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedSlider(
+                focusNode: focusNodeSlider,
+                value: 0.5,
+                onChanged: (_) {},
+                child: const SizedBox(width: 200, height: 40),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the last element
+        focusNode3.requestFocus();
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        // Shift+Tab to previous element (slider)
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNodeSlider.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeSlider.dispose();
+        focusNode3.dispose();
+      });
+    });
+
+    group('Disabled Slider Focus Behavior', () {
+      testWidgets('Disabled slider should NOT receive focus via Tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeDisabledSlider = FocusNode(debugLabel: 'disabled');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedSlider(
+                focusNode: focusNodeDisabledSlider,
+                value: 0.5,
+                onChanged: (_) {},
+                enabled: false,
+                child: const SizedBox(width: 200, height: 40),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab should skip disabled slider
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          focusNodeDisabledSlider.hasFocus,
+          isFalse,
+          reason: 'Disabled slider should not receive focus',
+        );
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeDisabledSlider.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets(
+        'Slider with null onChanged should NOT receive focus via Tab',
+        (WidgetTester tester) async {
+          final focusNode1 = FocusNode(debugLabel: 'before');
+          final focusNodeNullSlider = FocusNode(debugLabel: 'null onChanged');
+          final focusNode3 = FocusNode(debugLabel: 'after');
+
+          await tester.pumpMaterialWidget(
+            Column(
+              children: [
+                TextField(focusNode: focusNode1),
+                NakedSlider(
+                  focusNode: focusNodeNullSlider,
+                  value: 0.5,
+                  onChanged: null, // Non-interactive
+                  child: const SizedBox(width: 200, height: 40),
+                ),
+                TextField(focusNode: focusNode3),
+              ],
+            ),
+          );
+
+          // Focus the first element
+          focusNode1.requestFocus();
+          await tester.pump();
+
+          // Tab should skip slider with null onChanged
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pump();
+          expect(focusNodeNullSlider.hasFocus, isFalse);
+          expect(focusNode3.hasFocus, isTrue);
+
+          focusNode1.dispose();
+          focusNodeNullSlider.dispose();
+          focusNode3.dispose();
+        },
+      );
+    });
+
+    group('Arrow Key Navigation', () {
+      testWidgets('Arrow Right increases value', (WidgetTester tester) async {
+        double currentValue = 0.5;
+        const keyboardStep = 0.1;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            keyboardStep: keyboardStep,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        final initialValue = currentValue;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        expect(currentValue, initialValue + keyboardStep);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Arrow Left decreases value', (WidgetTester tester) async {
+        double currentValue = 0.5;
+        const keyboardStep = 0.1;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            keyboardStep: keyboardStep,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        final initialValue = currentValue;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+
+        expect(currentValue, initialValue - keyboardStep);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Arrow Up increases value', (WidgetTester tester) async {
+        double currentValue = 0.5;
+        const keyboardStep = 0.1;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            keyboardStep: keyboardStep,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+        final initialValue = currentValue;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+
+        expect(currentValue, initialValue + keyboardStep);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Arrow Down decreases value', (WidgetTester tester) async {
+        double currentValue = 0.5;
+        const keyboardStep = 0.1;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            keyboardStep: keyboardStep,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+        final initialValue = currentValue;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        expect(currentValue, initialValue - keyboardStep);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Home/End Keys', () {
+      testWidgets('Home sets value to minimum', (WidgetTester tester) async {
+        double currentValue = 0.5;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            min: 0.0,
+            max: 1.0,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.home);
+        await tester.pump();
+
+        expect(currentValue, 0.0);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('End sets value to maximum', (WidgetTester tester) async {
+        double currentValue = 0.5;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            min: 0.0,
+            max: 1.0,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.end);
+        await tester.pump();
+
+        expect(currentValue, 1.0);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Page Up/Down Keys', () {
+      testWidgets('Page Up increases value by larger step', (
+        WidgetTester tester,
+      ) async {
+        double currentValue = 0.5;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            largeKeyboardStep: 0.2,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+        final initialValue = currentValue;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.pageUp);
+        await tester.pump();
+
+        expect(currentValue, initialValue + 0.2);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Page Down decreases value by larger step', (
+        WidgetTester tester,
+      ) async {
+        double currentValue = 0.5;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            largeKeyboardStep: 0.2,
+            onChanged: (value) => currentValue = value,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+        final initialValue = currentValue;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.pageDown);
+        await tester.pump();
+
+        expect(currentValue, initialValue - 0.2);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when focus is gained', (
+        WidgetTester tester,
+      ) async {
+        bool focusState = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            value: 0.5,
+            onChanged: (_) {},
+            onFocusChange: (focused) => focusState = focused,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusState, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Autofocus', () {
+      testWidgets('Slider with autofocus receives initial focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedSlider(
+            focusNode: focusNode,
+            autofocus: true,
+            value: 0.5,
+            onChanged: (_) {},
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/tabs_focus_test.dart
+++ b/packages/naked_ui/test/focus/tabs_focus_test.dart
@@ -1,0 +1,744 @@
+/// ARIA Focus Behavior Tests for NakedTabs
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab (into tablist): Focus lands on the **selected tab**; if none selected, first tab
+/// - Tab (from tablist): Focus moves to the **tab panel** content (or next focusable outside)
+/// - Arrow Left/Up: Moves focus to previous tab
+/// - Arrow Right/Down: Moves focus to next tab
+/// - Home: Moves focus to first tab
+/// - End: Moves focus to last tab
+/// - Space/Enter: Activates the focused tab (in manual activation mode)
+///
+/// Activation Modes:
+/// - **Automatic**: Moving focus with arrows immediately activates (shows) the tab panel
+/// - **Manual**: Arrow keys only move focus; user must press Space/Enter to activate
+///
+/// Focus Management:
+/// - Uses **roving `tabindex`** within tablist
+/// - Tablist is ONE tab stop
+/// - Tab panels should be focusable only if they contain no focusable content
+/// - Arrow keys should wrap from last tab to first (and vice versa)
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedTabs ARIA Focus Behavior', () {
+    group('Tab Navigation - Single Tab Stop for Tablist', () {
+      testWidgets('Tab enters tablist on selected tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              NakedTabs(
+                selectedTabId: 'tab2',
+                onChanged: (_) {},
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: const [
+                          NakedTab(tabId: 'tab1', child: Text('Tab 1')),
+                          NakedTab(tabId: 'tab2', child: Text('Tab 2')),
+                          NakedTab(tabId: 'tab3', child: Text('Tab 3')),
+                        ],
+                      ),
+                    ),
+                    const NakedTabView(tabId: 'tab1', child: Text('Content 1')),
+                    const NakedTabView(tabId: 'tab2', child: Text('Content 2')),
+                    const NakedTabView(tabId: 'tab3', child: Text('Content 3')),
+                  ],
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should enter the tablist
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+
+        // Focus should be within the tablist (on selected tab)
+        expect(focusNodeBefore.hasFocus, isFalse);
+        expect(focusNodeAfter.hasFocus, isFalse);
+
+        focusNodeBefore.dispose();
+        focusNodeAfter.dispose();
+      });
+    });
+
+    group('Arrow Key Navigation', () {
+      testWidgets('Arrow Right moves focus to next tab', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab1';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+        final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+          tab3FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            autofocus: true,
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Right should move to next tab and select it (automatic activation)
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab2');
+        expect(tab2FocusNode.hasFocus, isTrue);
+      });
+
+      testWidgets('Arrow Left moves focus to previous tab', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab2';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+        final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+          tab3FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            autofocus: true,
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab3',
+                            focusNode: tab3FocusNode,
+                            child: Text('Tab 3'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Left should move to previous tab and select it
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab1');
+        expect(tab1FocusNode.hasFocus, isTrue);
+      });
+
+      testWidgets('Arrow Down moves focus to next tab (vertical orientation)', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab1';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                orientation: Axis.vertical,
+                child: Row(
+                  children: [
+                    NakedTabBar(
+                      child: Column(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            autofocus: true,
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Down should move to next tab in vertical orientation
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab2');
+        expect(tab2FocusNode.hasFocus, isTrue);
+      });
+
+      testWidgets(
+        'Arrow Up moves focus to previous tab (vertical orientation)',
+        (WidgetTester tester) async {
+          String selectedTabId = 'tab2';
+          final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+          final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+          final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+          addTearDown(() {
+            tab1FocusNode.dispose();
+            tab2FocusNode.dispose();
+            tab3FocusNode.dispose();
+          });
+
+          await tester.pumpMaterialWidget(
+            StatefulBuilder(
+              builder: (context, setState) {
+                return NakedTabs(
+                  selectedTabId: selectedTabId,
+                  onChanged: (id) => setState(() => selectedTabId = id),
+                  orientation: Axis.vertical,
+                  child: Row(
+                    children: [
+                      NakedTabBar(
+                        child: Column(
+                          children: [
+                            NakedTab(
+                              tabId: 'tab1',
+                              focusNode: tab1FocusNode,
+                              child: Text('Tab 1'),
+                            ),
+                            NakedTab(
+                              tabId: 'tab2',
+                              autofocus: true,
+                              focusNode: tab2FocusNode,
+                              child: Text('Tab 2'),
+                            ),
+                            NakedTab(
+                              tabId: 'tab3',
+                              focusNode: tab3FocusNode,
+                              child: Text('Tab 3'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          );
+
+          await tester.pump();
+
+          // Arrow Up should move to previous tab in vertical orientation
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+          await tester.pump();
+
+          expect(selectedTabId, 'tab1');
+          expect(tab1FocusNode.hasFocus, isTrue);
+        },
+      );
+
+      testWidgets('Arrow Down wraps from last tab to first tab (vertical)', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab3';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+        final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+          tab3FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                orientation: Axis.vertical,
+                child: Row(
+                  children: [
+                    NakedTabBar(
+                      child: Column(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab3',
+                            autofocus: true,
+                            focusNode: tab3FocusNode,
+                            child: Text('Tab 3'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Down on last tab should wrap to first tab
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab1');
+        expect(tab1FocusNode.hasPrimaryFocus, isTrue);
+      });
+
+      testWidgets('Arrow Up wraps from first tab to last tab (vertical)', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab1';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+        final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+          tab3FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                orientation: Axis.vertical,
+                child: Row(
+                  children: [
+                    NakedTabBar(
+                      child: Column(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            autofocus: true,
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab3',
+                            focusNode: tab3FocusNode,
+                            child: Text('Tab 3'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Up on first tab should wrap to last tab
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab3');
+        expect(tab3FocusNode.hasFocus, isTrue);
+      });
+
+      testWidgets('Arrow Left wraps from first tab to last tab (horizontal)', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab1';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+        final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+          tab3FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            autofocus: true,
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab3',
+                            focusNode: tab3FocusNode,
+                            child: Text('Tab 3'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Left on first tab should wrap to last tab
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab3');
+        expect(tab3FocusNode.hasFocus, isTrue);
+      });
+
+      testWidgets('Arrow Right wraps from last tab to first tab (horizontal)', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab3';
+        final tab1FocusNode = FocusNode(debugLabel: 'tab1');
+        final tab2FocusNode = FocusNode(debugLabel: 'tab2');
+        final tab3FocusNode = FocusNode(debugLabel: 'tab3');
+
+        addTearDown(() {
+          tab1FocusNode.dispose();
+          tab2FocusNode.dispose();
+          tab3FocusNode.dispose();
+        });
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: [
+                          NakedTab(
+                            tabId: 'tab1',
+                            focusNode: tab1FocusNode,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            focusNode: tab2FocusNode,
+                            child: Text('Tab 2'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab3',
+                            autofocus: true,
+                            focusNode: tab3FocusNode,
+                            child: Text('Tab 3'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Right on last tab should wrap to first tab
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab1');
+        expect(tab1FocusNode.hasFocus, isTrue);
+      });
+    });
+
+    group('Home/End Keys', () {
+      testWidgets('Home moves focus to first tab', (WidgetTester tester) async {
+        String selectedTabId = 'tab3';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: const [
+                          NakedTab(tabId: 'tab1', child: Text('Tab 1')),
+                          NakedTab(tabId: 'tab2', child: Text('Tab 2')),
+                          NakedTab(
+                            tabId: 'tab3',
+                            autofocus: true,
+                            child: Text('Tab 3'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const NakedTabView(tabId: 'tab1', child: Text('Content 1')),
+                    const NakedTabView(tabId: 'tab2', child: Text('Content 2')),
+                    const NakedTabView(tabId: 'tab3', child: Text('Content 3')),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.home);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab1');
+      });
+
+      testWidgets('End moves focus to last tab', (WidgetTester tester) async {
+        String selectedTabId = 'tab1';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: const [
+                          NakedTab(
+                            tabId: 'tab1',
+                            autofocus: true,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(tabId: 'tab2', child: Text('Tab 2')),
+                          NakedTab(tabId: 'tab3', child: Text('Tab 3')),
+                        ],
+                      ),
+                    ),
+                    const NakedTabView(tabId: 'tab1', child: Text('Content 1')),
+                    const NakedTabView(tabId: 'tab2', child: Text('Content 2')),
+                    const NakedTabView(tabId: 'tab3', child: Text('Content 3')),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.end);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab3');
+      });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when tab gains focus', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+
+        await tester.pumpMaterialWidget(
+          NakedTabs(
+            selectedTabId: 'tab1',
+            onChanged: (_) {},
+            child: Column(
+              children: [
+                NakedTabBar(
+                  child: Row(
+                    children: [
+                      NakedTab(
+                        tabId: 'tab1',
+                        autofocus: true,
+                        onFocusChange: (focused) => focusState = focused,
+                        child: const Text('Tab 1'),
+                      ),
+                      const NakedTab(tabId: 'tab2', child: Text('Tab 2')),
+                    ],
+                  ),
+                ),
+                const NakedTabView(tabId: 'tab1', child: Text('Content 1')),
+                const NakedTabView(tabId: 'tab2', child: Text('Content 2')),
+              ],
+            ),
+          ),
+        );
+
+        await tester.pump();
+        expect(focusState, isTrue);
+      });
+    });
+
+    group('Disabled Tab Behavior', () {
+      testWidgets('Disabled tab is skipped in navigation', (
+        WidgetTester tester,
+      ) async {
+        String selectedTabId = 'tab1';
+
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return NakedTabs(
+                selectedTabId: selectedTabId,
+                onChanged: (id) => setState(() => selectedTabId = id),
+                child: Column(
+                  children: [
+                    NakedTabBar(
+                      child: Row(
+                        children: const [
+                          NakedTab(
+                            tabId: 'tab1',
+                            autofocus: true,
+                            child: Text('Tab 1'),
+                          ),
+                          NakedTab(
+                            tabId: 'tab2',
+                            enabled: false,
+                            child: Text('Tab 2 (disabled)'),
+                          ),
+                          NakedTab(tabId: 'tab3', child: Text('Tab 3')),
+                        ],
+                      ),
+                    ),
+                    const NakedTabView(tabId: 'tab1', child: Text('Content 1')),
+                    const NakedTabView(tabId: 'tab2', child: Text('Content 2')),
+                    const NakedTabView(tabId: 'tab3', child: Text('Content 3')),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.pump();
+
+        // Arrow Right should skip disabled tab2 and go to tab3
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        expect(selectedTabId, 'tab3');
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/textfield_focus_test.dart
+++ b/packages/naked_ui/test/focus/textfield_focus_test.dart
@@ -1,0 +1,322 @@
+/// ARIA Focus Behavior Tests for NakedTextField
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+///
+/// Focus Behavior:
+/// - Tab: Moves focus into/out of text field
+/// - Text field is a single tab stop
+/// - When focused, cursor appears and text input is active
+///
+/// Keyboard Interaction:
+/// - Standard text editing keys work (typing, backspace, delete, etc.)
+/// - Arrow keys move cursor within text
+/// - Home/End move cursor to start/end of text
+/// - Ctrl+A selects all text
+/// - Escape: May clear selection or blur (implementation-specific)
+///
+/// Disabled State:
+/// - Disabled text field should NOT receive focus via Tab
+/// - Read-only text field CAN receive focus but cannot edit
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedTextField ARIA Focus Behavior', () {
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus to text field', (WidgetTester tester) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final textFieldFocusNode = FocusNode(debugLabel: 'textfield');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              NakedTextField(
+                controller: controller,
+                focusNode: textFieldFocusNode,
+                builder: (context, state, editableText) => Container(
+                  decoration: BoxDecoration(border: Border.all()),
+                  child: editableText,
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should move to text field
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(textFieldFocusNode.hasFocus, isTrue);
+
+        // Tab again should move to element after text field
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeAfter.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        textFieldFocusNode.dispose();
+        focusNodeAfter.dispose();
+        controller.dispose();
+      });
+
+      testWidgets('Shift+Tab moves focus to previous element', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final textFieldFocusNode = FocusNode(debugLabel: 'textfield');
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              NakedTextField(
+                controller: controller,
+                autofocus: true,
+                focusNode: textFieldFocusNode,
+                builder: (context, state, editableText) => Container(
+                  decoration: BoxDecoration(border: Border.all()),
+                  child: editableText,
+                ),
+              ),
+            ],
+          ),
+        );
+
+        // Shift+Tab should move to previous element
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        textFieldFocusNode.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Text Input', () {
+      testWidgets('Text can be entered when focused', (
+        WidgetTester tester,
+      ) async {
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          NakedTextField(
+            controller: controller,
+            autofocus: true,
+            builder: (context, state, editableText) => Container(
+              decoration: BoxDecoration(border: Border.all()),
+              child: editableText,
+            ),
+          ),
+        );
+
+        // Enter text
+        await tester.enterText(find.byType(EditableText), 'Hello World');
+        await tester.pump();
+
+        expect(controller.text, 'Hello World');
+
+        controller.dispose();
+      });
+    });
+
+    group('Disabled State', () {
+      testWidgets('Disabled text field should NOT receive focus via Tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNodeBefore = FocusNode(debugLabel: 'before');
+        final textFieldFocusNode = FocusNode(debugLabel: 'textfield');
+        final focusNodeAfter = FocusNode(debugLabel: 'after');
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNodeBefore),
+              NakedTextField(
+                controller: controller,
+                focusNode: textFieldFocusNode,
+                enabled: false,
+                builder: (context, state, editableText) => Container(
+                  decoration: BoxDecoration(border: Border.all()),
+                  child: editableText,
+                ),
+              ),
+              TextField(focusNode: focusNodeAfter),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNodeBefore.requestFocus();
+        await tester.pump();
+        expect(focusNodeBefore.hasFocus, isTrue);
+
+        // Tab should skip disabled text field
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(textFieldFocusNode.hasFocus, isFalse);
+        expect(focusNodeAfter.hasFocus, isTrue);
+
+        focusNodeBefore.dispose();
+        textFieldFocusNode.dispose();
+        focusNodeAfter.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Read-Only State', () {
+      testWidgets('Read-only text field CAN receive focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode = FocusNode();
+        final controller = TextEditingController(text: 'Read only text');
+
+        await tester.pumpMaterialWidget(
+          NakedTextField(
+            controller: controller,
+            focusNode: focusNode,
+            readOnly: true,
+            builder: (context, state, editableText) => Container(
+              decoration: BoxDecoration(border: Border.all()),
+              child: editableText,
+            ),
+          ),
+        );
+
+        // Focus the text field
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('NakedTextFieldState correctly reflects focused state', (
+        WidgetTester tester,
+      ) async {
+        NakedTextFieldState? capturedState;
+        final focusNode = FocusNode();
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          NakedTextField(
+            controller: controller,
+            focusNode: focusNode,
+            builder: (context, state, editableText) {
+              capturedState = state;
+              return Container(
+                decoration: BoxDecoration(border: Border.all()),
+                child: editableText,
+              );
+            },
+          ),
+        );
+
+        // Initially not focused
+        expect(capturedState?.isFocused, isFalse);
+
+        // Focus the text field
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(capturedState?.isFocused, isTrue);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('Autofocus', () {
+      testWidgets('Text field with autofocus receives initial focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode = FocusNode();
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          NakedTextField(
+            controller: controller,
+            focusNode: focusNode,
+            autofocus: true,
+            builder: (context, state, editableText) => Container(
+              decoration: BoxDecoration(border: Border.all()),
+              child: editableText,
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+        controller.dispose();
+      });
+    });
+
+    group('onFocusChange Callback', () {
+      testWidgets('onFocusChange is called when focus changes', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode = FocusNode();
+        final otherFocusNode = FocusNode();
+        final controller = TextEditingController();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedTextField(
+                controller: controller,
+                focusNode: focusNode,
+                onFocusChange: (focused) => focusState = focused,
+                builder: (context, state, editableText) => Container(
+                  decoration: BoxDecoration(border: Border.all()),
+                  child: editableText,
+                ),
+              ),
+              TextField(focusNode: otherFocusNode),
+            ],
+          ),
+        );
+
+        // Focus the text field
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(focusState, isTrue);
+
+        // Move focus away
+        otherFocusNode.requestFocus();
+        await tester.pump();
+        expect(focusState, isFalse);
+
+        focusNode.dispose();
+        otherFocusNode.dispose();
+        controller.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/focus/toggle_focus_test.dart
+++ b/packages/naked_ui/test/focus/toggle_focus_test.dart
@@ -1,0 +1,385 @@
+/// ARIA Focus Behavior Tests for NakedToggle (Switch)
+///
+/// Tests compliance with WAI-ARIA Authoring Practices Guide (APG) focus behavior:
+/// - Tab: Switch receives focus in natural tab order
+/// - Space: Toggles the switch on/off
+/// - Enter: (Optional) May also toggle
+///
+/// States:
+/// - `aria-checked="true"` — on
+/// - `aria-checked="false"` — off
+///
+/// Reference: ARIA_FOCUS_BEHAVIOR.md
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('NakedToggle ARIA Focus Behavior', () {
+    group('Tab Navigation', () {
+      testWidgets('Tab moves focus to toggle in natural tab order', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeToggle = FocusNode(debugLabel: 'toggle');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedToggle(
+                focusNode: focusNodeToggle,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Toggle'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab to next element (toggle)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNodeToggle.hasFocus, isTrue);
+
+        // Tab to next element (after toggle)
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeToggle.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets('Shift+Tab moves focus to previous element', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeToggle = FocusNode(debugLabel: 'toggle');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedToggle(
+                focusNode: focusNodeToggle,
+                value: false,
+                onChanged: (_) {},
+                child: const Text('Toggle'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the last element
+        focusNode3.requestFocus();
+        await tester.pump();
+        expect(focusNode3.hasFocus, isTrue);
+
+        // Shift+Tab to previous element (toggle)
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.pump();
+        expect(focusNodeToggle.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeToggle.dispose();
+        focusNode3.dispose();
+      });
+    });
+
+    group('Disabled Toggle Focus Behavior', () {
+      testWidgets('Disabled toggle should NOT receive focus via Tab', (
+        WidgetTester tester,
+      ) async {
+        final focusNode1 = FocusNode(debugLabel: 'before');
+        final focusNodeDisabledToggle = FocusNode(debugLabel: 'disabled');
+        final focusNode3 = FocusNode(debugLabel: 'after');
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              TextField(focusNode: focusNode1),
+              NakedToggle(
+                focusNode: focusNodeDisabledToggle,
+                value: false,
+                onChanged: (_) {},
+                enabled: false,
+                child: const Text('Disabled Toggle'),
+              ),
+              TextField(focusNode: focusNode3),
+            ],
+          ),
+        );
+
+        // Focus the first element
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusNode1.hasFocus, isTrue);
+
+        // Tab should skip disabled toggle
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          focusNodeDisabledToggle.hasFocus,
+          isFalse,
+          reason: 'Disabled toggle should not receive focus',
+        );
+        expect(focusNode3.hasFocus, isTrue);
+
+        focusNode1.dispose();
+        focusNodeDisabledToggle.dispose();
+        focusNode3.dispose();
+      });
+
+      testWidgets(
+        'Toggle with null onChanged should NOT receive focus via Tab',
+        (WidgetTester tester) async {
+          final focusNode1 = FocusNode(debugLabel: 'before');
+          final focusNodeNullToggle = FocusNode(debugLabel: 'null onChanged');
+          final focusNode3 = FocusNode(debugLabel: 'after');
+
+          await tester.pumpMaterialWidget(
+            Column(
+              children: [
+                TextField(focusNode: focusNode1),
+                NakedToggle(
+                  focusNode: focusNodeNullToggle,
+                  value: false,
+                  onChanged: null, // Non-interactive
+                  child: const Text('Non-interactive Toggle'),
+                ),
+                TextField(focusNode: focusNode3),
+              ],
+            ),
+          );
+
+          // Focus the first element
+          focusNode1.requestFocus();
+          await tester.pump();
+
+          // Tab should skip toggle with null onChanged
+          await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+          await tester.pump();
+          expect(focusNodeNullToggle.hasFocus, isFalse);
+          expect(focusNode3.hasFocus, isTrue);
+
+          focusNode1.dispose();
+          focusNodeNullToggle.dispose();
+          focusNode3.dispose();
+        },
+      );
+    });
+
+    group('Keyboard Activation - Space Key', () {
+      testWidgets('Space key toggles off to on', (WidgetTester tester) async {
+        bool currentValue = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedToggle(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            child: const Text('Space Test'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(currentValue, isFalse);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(currentValue, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Space key toggles on to off', (WidgetTester tester) async {
+        bool currentValue = true;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedToggle(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            child: const Text('Space Test'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(currentValue, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(currentValue, isFalse);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Space key does not toggle disabled switch', (
+        WidgetTester tester,
+      ) async {
+        bool currentValue = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedToggle(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            enabled: false,
+            child: const Text('Disabled'),
+          ),
+        );
+
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pump();
+
+        expect(currentValue, isFalse, reason: 'Value should not change');
+
+        focusNode.dispose();
+      });
+
+      testWidgets('Enter key also toggles switch', (WidgetTester tester) async {
+        bool currentValue = false;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedToggle(
+            focusNode: focusNode,
+            autofocus: true,
+            value: currentValue,
+            onChanged: (value) => currentValue = value,
+            child: const Text('Enter Test'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(currentValue, isFalse);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+
+        expect(currentValue, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+
+    group('Focus State Reporting', () {
+      testWidgets('onFocusChange is called when focus is gained', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedToggle(
+            focusNode: focusNode,
+            value: false,
+            onChanged: (_) {},
+            onFocusChange: (focused) => focusState = focused,
+            child: const Text('Focus Test'),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusState, isTrue);
+
+        focusNode.dispose();
+      });
+
+      testWidgets('onFocusChange is called when focus is lost', (
+        WidgetTester tester,
+      ) async {
+        bool? focusState;
+        final focusNode1 = FocusNode();
+        final focusNode2 = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          Column(
+            children: [
+              NakedToggle(
+                focusNode: focusNode1,
+                value: false,
+                onChanged: (_) {},
+                onFocusChange: (focused) => focusState = focused,
+                child: const Text('Toggle 1'),
+              ),
+              TextField(focusNode: focusNode2),
+            ],
+          ),
+        );
+
+        // Gain focus
+        focusNode1.requestFocus();
+        await tester.pump();
+        expect(focusState, isTrue);
+
+        // Lose focus
+        focusNode2.requestFocus();
+        await tester.pump();
+        expect(focusState, isFalse);
+
+        focusNode1.dispose();
+        focusNode2.dispose();
+      });
+    });
+
+    group('Autofocus', () {
+      testWidgets('Toggle with autofocus receives initial focus', (
+        WidgetTester tester,
+      ) async {
+        final focusNode = FocusNode();
+
+        await tester.pumpMaterialWidget(
+          NakedToggle(
+            focusNode: focusNode,
+            autofocus: true,
+            value: false,
+            onChanged: (_) {},
+            child: const Text('Autofocus Toggle'),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+
+        focusNode.dispose();
+      });
+    });
+  });
+}

--- a/packages/naked_ui/test/src/naked_button_test.dart
+++ b/packages/naked_ui/test/src/naked_button_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart' as m;
 import 'package:flutter/gestures.dart' show kLongPressTimeout;
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
@@ -45,27 +44,7 @@ void main() {
       expect(wasPressed, isFalse);
     });
 
-    testWidgets('does not respond to keyboard when disabled', (
-      WidgetTester tester,
-    ) async {
-      bool wasPressed = false;
-      await tester.pumpMaterialWidget(
-        NakedButton(
-          autofocus: true,
-          onPressed: () => wasPressed = true,
-          enabled: false,
-          child: const Text('Test Button'),
-        ),
-      );
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pump();
-      expect(wasPressed, isFalse);
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.space);
-      await tester.pump();
-      expect(wasPressed, isFalse);
-    });
+    // Keyboard interaction tests moved to focus/button_focus_test.dart
 
     testWidgets('does not respond when onPressed is null', (
       WidgetTester tester,
@@ -301,95 +280,7 @@ void main() {
     );
   });
 
-  group('Keyboard Interaction', () {
-    testWidgets('activates with Space key', (WidgetTester tester) async {
-      bool wasPressed = false;
-
-      await tester.pumpMaterialWidget(
-        NakedButton(
-          autofocus: true,
-          onPressed: () => wasPressed = true,
-          child: const Text('Test Button'),
-        ),
-      );
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.space);
-      await tester.pump();
-
-      expect(wasPressed, true);
-    });
-
-    testWidgets('activates with Enter key', (WidgetTester tester) async {
-      bool wasPressed = false;
-      await tester.pumpMaterialWidget(
-        NakedButton(
-          onPressed: () => wasPressed = true,
-          child: const Text('Test Button'),
-        ),
-      );
-
-      await tester.tap(find.byType(NakedButton));
-      await tester.pump();
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pump();
-
-      expect(wasPressed, true);
-    });
-  });
-
-  group('Focus Behavior', () {
-    testWidgets('focusOnPress requests focus when button is pressed', (
-      WidgetTester tester,
-    ) async {
-      final focusNode = FocusNode();
-      final key = UniqueKey();
-
-      await tester.pumpMaterialWidget(
-        NakedButton(
-          key: key,
-          onPressed: () {},
-          focusOnPress: true,
-          focusNode: focusNode,
-          child: const Text('Focus On Press'),
-        ),
-      );
-
-      expect(focusNode.hasFocus, isFalse);
-
-      // Tap the button
-      await tester.tap(find.byKey(key));
-      await tester.pump();
-
-      expect(focusNode.hasFocus, isTrue);
-    });
-
-    testWidgets('focusOnPress false does not request focus on press', (
-      WidgetTester tester,
-    ) async {
-      final focusNode = FocusNode();
-      final key = UniqueKey();
-
-      await tester.pumpMaterialWidget(
-        NakedButton(
-          key: key,
-          onPressed: () {},
-          focusOnPress: false, // default
-          focusNode: focusNode,
-          child: const Text('No Focus On Press'),
-        ),
-      );
-
-      expect(focusNode.hasFocus, isFalse);
-
-      // Tap the button
-      await tester.tap(find.byKey(key));
-      await tester.pump();
-
-      // Focus should not have been requested
-      expect(focusNode.hasFocus, isFalse);
-    });
-  });
+  // Keyboard Interaction tests moved to focus/button_focus_test.dart
 
   group('Cursor', () {
     testWidgets('shows appropriate cursor based on interactive state', (

--- a/packages/naked_ui/test/src/naked_checkbox_test.dart
+++ b/packages/naked_ui/test/src/naked_checkbox_test.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart' as m;
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
+
+// Note: Keyboard interaction and focus behavior tests are in focus/checkbox_focus_test.dart
 
 import '../test_helpers.dart';
 import 'helpers/builder_state_scope.dart';
@@ -253,55 +254,6 @@ void main() {
       focusNodeOther.requestFocus();
       await tester.pump();
       expect(isFocused, false);
-    });
-  });
-
-  group('Keyboard Interaction', () {
-    testWidgets('toggles with Space key', (WidgetTester tester) async {
-      bool isChecked = false;
-
-      final focusNode = FocusNode();
-      await tester.pumpMaterialWidget(
-        NakedCheckbox(
-          value: isChecked,
-          autofocus: true,
-          onChanged: (value) => isChecked = value!,
-          focusNode: focusNode,
-          child: const Text('Checkbox Label'),
-        ),
-      );
-
-      // Give time for autofocus to take effect
-      await tester.pump();
-
-      expect(isChecked, false);
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.space);
-      await tester.pump();
-
-      expect(isChecked, true);
-    });
-
-    testWidgets('toggles with Enter key', (WidgetTester tester) async {
-      bool isChecked = false;
-      final focusNode = FocusNode();
-      await tester.pumpMaterialWidget(
-        NakedCheckbox(
-          value: isChecked,
-          onChanged: (value) => isChecked = value!,
-          focusNode: focusNode,
-          autofocus: true,
-          child: const Text('Checkbox Label'),
-        ),
-      );
-
-      // Give time for autofocus to take effect
-      await tester.pump();
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pump();
-
-      expect(isChecked, true);
     });
   });
 


### PR DESCRIPTION
## Description

Adds comprehensive focus behavior tests for Accordion, Button, and Checkbox. Updates NakedDialog to auto-focus the first focusable element on mount. Refines popover and textfield focus handling for ARIA compliance. Minor UI and code improvements in example and popover components.

## Related Issues

#46 

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [ ] I have updated or added relevant documentation (doc comments with `///`).
- [ ] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.