### PR TITLE
fix(naked-ui): correct accessibility semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.41.2'
           cache: true
 
       - name: Install dependencies (workspace)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run tests
         run: flutter test packages/naked_ui/test --coverage
 
+      - name: Run example tests
+        run: flutter test packages/example/test
+
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.41.2'
           cache: true
       - run: flutter --version
       - run: flutter pub get

--- a/.github/workflows/integration-android.yml
+++ b/.github/workflows/integration-android.yml
@@ -29,6 +29,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.41.2'
           cache: true
 
       - name: Flutter doctor

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.41.2'
           cache: true
 
       - name: Enable macOS desktop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.41.2'
           cache: true
 
       - name: Install dependencies

--- a/packages/example/lib/api/naked_semantics_playground.dart
+++ b/packages/example/lib/api/naked_semantics_playground.dart
@@ -1,0 +1,452 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+void main() {
+  runApp(const SemanticsPlaygroundApp());
+}
+
+class SemanticsPlaygroundApp extends StatelessWidget {
+  const SemanticsPlaygroundApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(body: SemanticsPlayground()),
+    );
+  }
+}
+
+class SemanticsPlayground extends StatefulWidget {
+  const SemanticsPlayground({super.key});
+
+  @override
+  State<SemanticsPlayground> createState() => _SemanticsPlaygroundState();
+}
+
+class _SemanticsPlaygroundState extends State<SemanticsPlayground> {
+  late final SemanticsHandle _semanticsHandle;
+
+  @override
+  void initState() {
+    super.initState();
+    _semanticsHandle = SemanticsBinding.instance.ensureSemantics();
+  }
+
+  @override
+  void dispose() {
+    _semanticsHandle.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 900),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            spacing: 16,
+            children: const [
+              Text(
+                'Semantics Playground',
+                style: TextStyle(fontSize: 26, fontWeight: FontWeight.w700),
+              ),
+              _Scenario(
+                title: 'Menu',
+                defaultChild: _MenuDemo(label: 'Default menu'),
+                overrideChild: _MenuDemo(
+                  label: 'Visual menu',
+                  semanticLabel: 'Override menu trigger',
+                ),
+              ),
+              _Scenario(
+                title: 'Accordion',
+                defaultChild: _AccordionDemo(label: 'Default accordion'),
+                overrideChild: _AccordionDemo(
+                  label: 'Visual accordion',
+                  semanticLabel: 'Override accordion trigger',
+                ),
+              ),
+              _Scenario(
+                title: 'Radio',
+                defaultChild: _RadioDemo(label: 'Default radio'),
+                overrideChild: _RadioDemo(
+                  label: 'Visual radio',
+                  semanticLabel: 'Override radio option',
+                ),
+              ),
+              _Scenario(
+                title: 'Select',
+                defaultChild: _SelectDemo(label: 'Default select'),
+                overrideChild: _SelectDemo(
+                  label: 'Visual select',
+                  semanticLabel: 'Override select trigger',
+                ),
+              ),
+              _Scenario(
+                title: 'Slider',
+                defaultChild: _SliderDemo(label: 'Default slider'),
+                overrideChild: _SliderDemo(
+                  label: 'Override slider',
+                  formatterPrefix: 'Override slider percent',
+                ),
+              ),
+              _Scenario(
+                title: 'Text field',
+                defaultChild: _TextFieldDemo(label: 'Default text field'),
+                overrideChild: _TextFieldDemo(
+                  label: 'Override text field',
+                  errorText: 'Override text field error',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Scenario extends StatelessWidget {
+  const _Scenario({
+    required this.title,
+    required this.defaultChild,
+    required this.overrideChild,
+  });
+
+  final String title;
+  final Widget defaultChild;
+  final Widget overrideChild;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.shade300),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 12,
+          children: [
+            Text(title, style: const TextStyle(fontWeight: FontWeight.w700)),
+            Wrap(
+              spacing: 16,
+              runSpacing: 16,
+              children: [
+                _Variant(label: 'Default semantics', child: defaultChild),
+                _Variant(label: 'Override semantics', child: overrideChild),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Variant extends StatelessWidget {
+  const _Variant({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 260,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 8,
+        children: [
+          Text(label, style: TextStyle(color: Colors.grey.shade700)),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuDemo extends StatefulWidget {
+  const _MenuDemo({required this.label, this.semanticLabel});
+
+  final String label;
+  final String? semanticLabel;
+
+  @override
+  State<_MenuDemo> createState() => _MenuDemoState();
+}
+
+class _MenuDemoState extends State<_MenuDemo> {
+  final _controller = MenuController();
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedMenu<String>(
+      controller: _controller,
+      semanticLabel: widget.semanticLabel,
+      builder: (context, state, child) => _BoxedControl(
+        pressed: state.isPressed,
+        focused: state.isFocused,
+        child: Text(widget.label),
+      ),
+      overlayBuilder: (context, info) => DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: Colors.grey.shade300),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: NakedMenuItem<String>(
+          value: 'first',
+          semanticLabel: '${widget.label} item',
+          builder: (context, state, child) => const Padding(
+            padding: EdgeInsets.all(12),
+            child: Text('First action'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AccordionDemo extends StatefulWidget {
+  const _AccordionDemo({required this.label, this.semanticLabel});
+
+  final String label;
+  final String? semanticLabel;
+
+  @override
+  State<_AccordionDemo> createState() => _AccordionDemoState();
+}
+
+class _AccordionDemoState extends State<_AccordionDemo> {
+  late final NakedAccordionController<String> _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = NakedAccordionController<String>();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedAccordionGroup<String>(
+      controller: _controller,
+      initialExpandedValues: const [],
+      child: NakedAccordion<String>(
+        value: widget.label,
+        semanticLabel: widget.semanticLabel,
+        builder: (context, state) => _BoxedControl(
+          pressed: state.isPressed,
+          focused: state.isFocused,
+          child: Text(widget.label),
+        ),
+        child: const Padding(
+          padding: EdgeInsets.only(top: 8),
+          child: Text('Accordion content'),
+        ),
+      ),
+    );
+  }
+}
+
+class _RadioDemo extends StatefulWidget {
+  const _RadioDemo({required this.label, this.semanticLabel});
+
+  final String label;
+  final String? semanticLabel;
+
+  @override
+  State<_RadioDemo> createState() => _RadioDemoState();
+}
+
+class _RadioDemoState extends State<_RadioDemo> {
+  String _value = 'current';
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioGroup<String>(
+      groupValue: _value,
+      onChanged: (value) => setState(() => _value = value ?? _value),
+      child: NakedRadio<String>(
+        value: 'current',
+        semanticLabel: widget.semanticLabel,
+        builder: (context, state, child) => _BoxedControl(
+          pressed: state.isPressed,
+          focused: state.isFocused,
+          child: Text(widget.label),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectDemo extends StatefulWidget {
+  const _SelectDemo({required this.label, this.semanticLabel});
+
+  final String label;
+  final String? semanticLabel;
+
+  @override
+  State<_SelectDemo> createState() => _SelectDemoState();
+}
+
+class _SelectDemoState extends State<_SelectDemo> {
+  String _value = 'one';
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedSelect<String>(
+      value: _value,
+      semanticLabel: widget.semanticLabel,
+      onChanged: (value) => setState(() => _value = value ?? _value),
+      builder: (context, state, child) => _BoxedControl(
+        pressed: state.isPressed,
+        focused: state.isFocused,
+        child: Text(widget.label),
+      ),
+      overlayBuilder: (context, info) => DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: Colors.grey.shade300),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final value in const ['one', 'two'])
+              NakedSelect.Option(
+                value: value,
+                semanticLabel: '${widget.label} option $value',
+                builder: (context, state, child) => Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text(value),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SliderDemo extends StatefulWidget {
+  const _SliderDemo({required this.label, this.formatterPrefix});
+
+  final String label;
+  final String? formatterPrefix;
+
+  @override
+  State<_SliderDemo> createState() => _SliderDemoState();
+}
+
+class _SliderDemoState extends State<_SliderDemo> {
+  double _value = 0.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 36,
+      child: NakedSlider(
+        value: _value,
+        semanticLabel: widget.label,
+        semanticFormatterCallback: widget.formatterPrefix == null
+            ? null
+            : (value) => '${widget.formatterPrefix} ${(value * 100).round()}',
+        onChanged: (value) => setState(() => _value = value),
+        child: CustomPaint(painter: _SliderPainter(_value)),
+      ),
+    );
+  }
+}
+
+class _TextFieldDemo extends StatelessWidget {
+  const _TextFieldDemo({required this.label, this.errorText});
+
+  final String label;
+  final String? errorText;
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedTextField(
+      semanticLabel: label,
+      semanticErrorText: errorText,
+      error: errorText != null,
+      builder: (context, state, editableText) => _BoxedControl(
+        focused: state.isFocused,
+        pressed: state.isPressed,
+        child: editableText,
+      ),
+    );
+  }
+}
+
+class _BoxedControl extends StatelessWidget {
+  const _BoxedControl({
+    required this.child,
+    required this.focused,
+    required this.pressed,
+  });
+
+  final Widget child;
+  final bool focused;
+  final bool pressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 100),
+      constraints: const BoxConstraints(minHeight: 44, minWidth: 180),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: pressed ? Colors.grey.shade100 : Colors.white,
+        border: Border.all(color: focused ? Colors.blue : Colors.grey.shade400),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Align(alignment: Alignment.centerLeft, child: child),
+    );
+  }
+}
+
+class _SliderPainter extends CustomPainter {
+  const _SliderPainter(this.value);
+
+  final double value;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final centerY = size.height / 2;
+    final active = Paint()
+      ..color = Colors.black
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+    final inactive = Paint()
+      ..color = Colors.black.withValues(alpha: 0.12)
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawLine(Offset(0, centerY), Offset(size.width, centerY), inactive);
+    canvas.drawLine(
+      Offset(0, centerY),
+      Offset(size.width * value, centerY),
+      active,
+    );
+    canvas.drawCircle(Offset(size.width * value, centerY), 8, active);
+  }
+
+  @override
+  bool shouldRepaint(_SliderPainter oldDelegate) => oldDelegate.value != value;
+}

--- a/packages/example/lib/registry.dart
+++ b/packages/example/lib/registry.dart
@@ -19,6 +19,8 @@ import 'api/naked_radio.0.dart' as radio_basic_example;
 import 'api/naked_select.0.dart' as select_example;
 import 'api/naked_select.2.dart' as select_checkmark_example;
 import 'api/naked_select.1.dart' as select_cyberpunk_example;
+// Semantics
+import 'api/naked_semantics_playground.dart' as semantics_playground;
 // Slider
 import 'api/naked_slider.0.dart' as slider_example;
 // Tabs
@@ -182,6 +184,15 @@ class DemoRegistry {
       sourceUrl:
           'https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_toggle.0.dart',
       tags: ['toggle'],
+    ),
+    Demo(
+      id: 'semantics-playground',
+      title: 'Semantics - Playground',
+      category: 'Semantics',
+      builder: (_) => const semantics_playground.SemanticsPlayground(),
+      sourceUrl:
+          'https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_semantics_playground.dart',
+      tags: ['semantics', 'accessibility', 'a11y'],
     ),
   ];
 

--- a/packages/example/test/semantics_playground_test.dart
+++ b/packages/example/test/semantics_playground_test.dart
@@ -1,0 +1,27 @@
+import 'package:example/main.dart';
+import 'package:example/registry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('semantics playground is registered and renders labels', (
+    WidgetTester tester,
+  ) async {
+    final demo = DemoRegistry.find('semantics-playground');
+
+    expect(demo, isNotNull);
+
+    await tester.pumpWidget(const MyApp());
+    await tester.enterText(find.byType(TextField), 'semantics');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Semantics - Playground'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Default semantics'), findsWidgets);
+    expect(find.text('Override semantics'), findsWidgets);
+    expect(find.text('Default menu'), findsOneWidget);
+    expect(find.text('Visual menu'), findsOneWidget);
+    expect(find.text('Default accordion'), findsOneWidget);
+    expect(find.text('Visual accordion'), findsOneWidget);
+  });
+}

--- a/packages/example/test/semantics_playground_test.dart
+++ b/packages/example/test/semantics_playground_test.dart
@@ -1,27 +1,337 @@
-import 'package:example/main.dart';
+import 'dart:ui' show CheckedState, Tristate;
+
+import 'package:example/api/naked_semantics_playground.dart';
 import 'package:example/registry.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('semantics playground is registered and renders labels', (
-    WidgetTester tester,
-  ) async {
-    final demo = DemoRegistry.find('semantics-playground');
+  Widget wrap(Widget child) => MaterialApp(
+    debugShowCheckedModeBanner: false,
+    home: Scaffold(body: child),
+  );
 
-    expect(demo, isNotNull);
-
-    await tester.pumpWidget(const MyApp());
-    await tester.enterText(find.byType(TextField), 'semantics');
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Semantics - Playground'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Default semantics'), findsWidgets);
-    expect(find.text('Override semantics'), findsWidgets);
-    expect(find.text('Default menu'), findsOneWidget);
-    expect(find.text('Visual menu'), findsOneWidget);
-    expect(find.text('Default accordion'), findsOneWidget);
-    expect(find.text('Visual accordion'), findsOneWidget);
+  testWidgets('semantics playground demo is registered', (tester) async {
+    expect(DemoRegistry.find('semantics-playground'), isNotNull);
   });
+
+  testWidgets('playground exposes expected Flutter semantics', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(wrap(const SemanticsPlayground()));
+    await tester.pumpAndSettle();
+
+    final root = tester.getSemantics(find.byType(Scaffold));
+    final dump = _dumpTree(root);
+    final labels = _collectLabels(root);
+
+    const defaultNames = [
+      'Default menu',
+      'Default accordion',
+      'Default radio',
+      'Default select',
+      'Default slider',
+      'Default text field',
+    ];
+    for (final name in defaultNames) {
+      expect(
+        labels,
+        contains(name),
+        reason: 'Missing default label "$name"\n$dump',
+      );
+    }
+
+    const overrideNames = [
+      'Override menu trigger',
+      'Override accordion trigger',
+      'Override radio option',
+      'Override select trigger',
+      'Override slider',
+      'Override text field',
+    ];
+    for (final name in overrideNames) {
+      expect(
+        labels,
+        contains(name),
+        reason: 'Missing override label "$name"\n$dump',
+      );
+    }
+
+    // Visual override labels must never be exposed on a control node.
+    for (final visual in const [
+      'Visual menu',
+      'Visual accordion',
+      'Visual radio',
+      'Visual select',
+    ]) {
+      final offenders = _collectAll(root, (node) {
+        final data = node.getSemanticsData();
+        return data.label == visual && _isControlNode(data);
+      });
+      expect(
+        offenders,
+        isEmpty,
+        reason: '"$visual" must not be a control label\n$dump',
+      );
+    }
+
+    // Menu, accordion, and select triggers all expose button + expanded state.
+    for (final entry in const <String, String>{
+      'Default menu': 'menu trigger (default)',
+      'Override menu trigger': 'menu trigger (override)',
+      'Default accordion': 'accordion trigger (default)',
+      'Override accordion trigger': 'accordion trigger (override)',
+      'Default select': 'select trigger (default)',
+      'Override select trigger': 'select trigger (override)',
+    }.entries) {
+      final node = _findByLabel(root, entry.key);
+      expect(
+        node,
+        isNotNull,
+        reason: 'Missing ${entry.value} node "${entry.key}"\n$dump',
+      );
+      final data = node!.getSemanticsData();
+      expect(
+        data.flagsCollection.isButton,
+        isTrue,
+        reason: '${entry.value} should be a button',
+      );
+      expect(
+        data.flagsCollection.isExpanded,
+        Tristate.isFalse,
+        reason: '${entry.value} should expose collapsed expanded state',
+      );
+      expect(
+        data.hasAction(SemanticsAction.tap),
+        isTrue,
+        reason: '${entry.value} should expose tap action',
+      );
+    }
+
+    // Radio: mutually exclusive group + checked.
+    for (final label in const ['Default radio', 'Override radio option']) {
+      final node = _findByLabel(root, label);
+      expect(node, isNotNull, reason: 'Missing radio "$label"\n$dump');
+      final data = node!.getSemanticsData();
+      expect(
+        data.flagsCollection.isInMutuallyExclusiveGroup,
+        isTrue,
+        reason: '"$label" should be in a radio group',
+      );
+      expect(
+        data.flagsCollection.isChecked,
+        CheckedState.isTrue,
+        reason: '"$label" should be checked (only option in the group)',
+      );
+    }
+
+    // Slider: slider flag + value/increase/decrease.
+    for (final label in const ['Default slider', 'Override slider']) {
+      final node = _findByLabel(root, label);
+      expect(node, isNotNull, reason: 'Missing slider "$label"\n$dump');
+      final data = node!.getSemanticsData();
+      expect(data.flagsCollection.isSlider, isTrue);
+      expect(
+        data.value,
+        isNotEmpty,
+        reason: '"$label" should expose a semantic value',
+      );
+      expect(data.increasedValue, isNotEmpty);
+      expect(data.decreasedValue, isNotEmpty);
+      expect(data.hasAction(SemanticsAction.increase), isTrue);
+      expect(data.hasAction(SemanticsAction.decrease), isTrue);
+    }
+    final overrideSliderData = _findByLabel(
+      root,
+      'Override slider',
+    )!.getSemanticsData();
+    expect(
+      overrideSliderData.value,
+      startsWith('Override slider percent'),
+      reason: 'override slider should use its semanticFormatterCallback',
+    );
+
+    // Text field: exactly two text fields, none nested.
+    bool isTextField(SemanticsNode node) =>
+        node.getSemanticsData().flagsCollection.isTextField;
+    final textFields = _collectAll(root, isTextField);
+    expect(
+      textFields,
+      hasLength(2),
+      reason: 'Expected exactly two text fields\n$dump',
+    );
+    _expectNoNested(root, predicate: isTextField, debugName: 'text field');
+
+    final tfLabels = textFields.map((n) => n.getSemanticsData().label).toSet();
+    expect(
+      tfLabels,
+      containsAll(<String>['Default text field', 'Override text field']),
+    );
+
+    final defaultTfData = textFields
+        .firstWhere((n) => n.getSemanticsData().label == 'Default text field')
+        .getSemanticsData();
+    expect(
+      defaultTfData.flagsCollection.isLiveRegion,
+      isFalse,
+      reason: 'default text field has no error, should not be live',
+    );
+
+    final overrideTfData = textFields
+        .firstWhere((n) => n.getSemanticsData().label == 'Override text field')
+        .getSemanticsData();
+    expect(
+      overrideTfData.flagsCollection.isLiveRegion,
+      isTrue,
+      reason: 'override text field error should be announced as live',
+    );
+    expect(
+      overrideTfData.hint,
+      contains('Override text field error'),
+      reason: 'override text field hint should include error text',
+    );
+
+    // Select triggers: identified by label, none nested.
+    bool isSelectTrigger(SemanticsNode node) {
+      final label = node.getSemanticsData().label;
+      return label == 'Default select' || label == 'Override select trigger';
+    }
+
+    final selects = _collectAll(root, isSelectTrigger);
+    expect(selects, hasLength(2));
+    _expectNoNested(
+      root,
+      predicate: isSelectTrigger,
+      debugName: 'select trigger',
+    );
+
+    // Unmount the playground so its internal SemanticsHandle is disposed,
+    // then dispose ours before the framework's leaked-handle check runs.
+    await tester.pumpWidget(const SizedBox.shrink());
+    handle.dispose();
+  });
+}
+
+List<SemanticsNode> _collectAll(
+  SemanticsNode root,
+  bool Function(SemanticsNode) predicate,
+) {
+  final out = <SemanticsNode>[];
+  void visit(SemanticsNode node) {
+    if (!node.isMergedIntoParent && predicate(node)) out.add(node);
+    node.visitChildren((child) {
+      visit(child);
+      return true;
+    });
+  }
+
+  visit(root);
+  return out;
+}
+
+SemanticsNode? _findByLabel(SemanticsNode root, String label) {
+  final matches = _collectAll(root, (n) => n.getSemanticsData().label == label);
+  return matches.isEmpty ? null : matches.first;
+}
+
+Set<String> _collectLabels(SemanticsNode root) {
+  final labels = <String>{};
+  void visit(SemanticsNode node) {
+    final raw = node.getSemanticsData().label;
+    if (raw.isNotEmpty) {
+      for (final part in raw.split('\n')) {
+        final trimmed = part.trim();
+        if (trimmed.isNotEmpty) labels.add(trimmed);
+      }
+    }
+    node.visitChildren((child) {
+      visit(child);
+      return true;
+    });
+  }
+
+  visit(root);
+  return labels;
+}
+
+bool _isControlNode(SemanticsData data) {
+  return data.flagsCollection.isButton ||
+      data.flagsCollection.isSlider ||
+      data.flagsCollection.isTextField ||
+      data.flagsCollection.isInMutuallyExclusiveGroup ||
+      data.flagsCollection.isChecked != CheckedState.none ||
+      data.flagsCollection.isToggled != Tristate.none ||
+      data.hasAction(SemanticsAction.tap) ||
+      data.hasAction(SemanticsAction.increase) ||
+      data.hasAction(SemanticsAction.decrease);
+}
+
+void _expectNoNested(
+  SemanticsNode root, {
+  required bool Function(SemanticsNode) predicate,
+  required String debugName,
+}) {
+  bool hasMatchingDescendant(SemanticsNode node) {
+    var found = false;
+    bool visit(SemanticsNode child) {
+      if (found) return true;
+      if (!child.isMergedIntoParent && predicate(child)) {
+        found = true;
+        return true;
+      }
+      child.visitChildren(visit);
+      return true;
+    }
+
+    node.visitChildren(visit);
+    return found;
+  }
+
+  final offenders = <SemanticsNode>[];
+  for (final node in _collectAll(root, predicate)) {
+    if (hasMatchingDescendant(node)) offenders.add(node);
+  }
+  expect(
+    offenders,
+    isEmpty,
+    reason: 'Expected no nested $debugName semantics nodes',
+  );
+}
+
+String _dumpTree(SemanticsNode root) {
+  final buf = StringBuffer('Semantics tree:\n');
+  void visit(SemanticsNode node, int depth) {
+    final data = node.getSemanticsData();
+    final parts = <String>[];
+    if (data.label.isNotEmpty) {
+      parts.add('label="${data.label.replaceAll('\n', '\\n')}"');
+    }
+    if (data.value.isNotEmpty) parts.add('value="${data.value}"');
+    if (data.hint.isNotEmpty) parts.add('hint="${data.hint}"');
+    if (data.flagsCollection.isButton) parts.add('button');
+    if (data.flagsCollection.isExpanded != Tristate.none) {
+      parts.add('expanded=${data.flagsCollection.isExpanded}');
+    }
+    if (data.flagsCollection.isSlider) parts.add('slider');
+    if (data.flagsCollection.isTextField) parts.add('textField');
+    if (data.flagsCollection.isInMutuallyExclusiveGroup) parts.add('radio');
+    if (data.flagsCollection.isChecked != CheckedState.none) {
+      parts.add('checked=${data.flagsCollection.isChecked}');
+    }
+    if (data.flagsCollection.isLiveRegion) parts.add('liveRegion');
+    buf.writeln('${'  ' * depth}#${node.id} ${parts.join(' ')}');
+    node.visitChildren((child) {
+      visit(child, depth + 1);
+      return true;
+    });
+  }
+
+  visit(root, 0);
+  return buf.toString();
 }

--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0-beta.7
 
 - fix: text style handling in NakedTextField
+- feat: improve 3.27-safe semantics for menu, select, accordion, checkbox, radio, slider, and text field
 
 ## 0.2.0-beta.6
 

--- a/packages/naked_ui/lib/src/naked_accordion.dart
+++ b/packages/naked_ui/lib/src/naked_accordion.dart
@@ -527,6 +527,15 @@ class _NakedAccordionState<T> extends State<NakedAccordion<T>>
       canExpand: canExpand,
     );
 
+    final Widget trigger = NakedStateScopeBuilder(
+      value: accordionState,
+      builder: (context, accordionState, child) =>
+          widget.builder(context, accordionState),
+    );
+
+    final bool excludeTriggerSemantics =
+        widget.excludeSemantics || widget.semanticLabel != null;
+
     Widget triggerContent = GestureDetector(
       onTapDown: (widget.enabled && widget.onPressChange != null)
           ? (_) => updatePressState(true, widget.onPressChange)
@@ -540,19 +549,17 @@ class _NakedAccordionState<T> extends State<NakedAccordion<T>>
           : null,
       behavior: HitTestBehavior.opaque,
       excludeFromSemantics: true,
-      child: ExcludeSemantics(
-        child: NakedStateScopeBuilder(
-          value: accordionState,
-          builder: (context, accordionState, child) =>
-              widget.builder(context, accordionState),
-        ),
-      ),
+      child: excludeTriggerSemantics
+          ? ExcludeSemantics(child: trigger)
+          : trigger,
     );
 
     Widget accordionChild = widget.excludeSemantics
         ? triggerContent
         : Semantics(
             enabled: widget.enabled,
+            button: true,
+            expanded: isExpanded,
             label: widget.semanticLabel,
             onTap: widget.enabled ? onTap : null,
             child: triggerContent,

--- a/packages/naked_ui/lib/src/naked_checkbox.dart
+++ b/packages/naked_ui/lib/src/naked_checkbox.dart
@@ -223,7 +223,6 @@ class _NakedCheckboxState extends State<NakedCheckbox>
     return widget.excludeSemantics
         ? gestureDetector
         : Semantics(
-            container: true,
             enabled: widget._effectiveEnabled,
             checked: widget.value == true,
             mixed: widget.tristate && widget.value == null,

--- a/packages/naked_ui/lib/src/naked_menu.dart
+++ b/packages/naked_ui/lib/src/naked_menu.dart
@@ -212,6 +212,7 @@ class NakedMenu<T> extends StatefulWidget {
     this.closeOnClickOutside = true,
     this.triggerFocusNode,
     this.positioning = const OverlayPositionConfig(),
+    this.semanticLabel,
     this.excludeSemantics = false,
   });
 
@@ -262,6 +263,9 @@ class NakedMenu<T> extends StatefulWidget {
   /// Overlay positioning configuration.
   final OverlayPositionConfig positioning;
 
+  /// Semantic label for the menu trigger.
+  final String? semanticLabel;
+
   /// Whether to exclude this widget from the semantic tree.
   ///
   /// When true, the widget and its children are hidden from accessibility services.
@@ -281,6 +285,7 @@ class _NakedMenuState<T> extends State<NakedMenu<T>>
 
   void _handleOpen() {
     handleOpen(widget.onOpen);
+    if (mounted) setState(() {});
   }
 
   void _handleClose() {
@@ -289,6 +294,7 @@ class _NakedMenuState<T> extends State<NakedMenu<T>>
       onCanceled: widget.onCanceled,
       triggerFocusNode: widget.triggerFocusNode,
     );
+    if (mounted) setState(() {});
   }
 
   void _handleSelection(T value) {
@@ -301,6 +307,7 @@ class _NakedMenuState<T> extends State<NakedMenu<T>>
     Widget button = NakedButton(
       onPressed: _toggle,
       focusNode: widget.triggerFocusNode,
+      semanticLabel: widget.semanticLabel,
       child: widget.child,
       builder: (context, buttonState, child) {
         final menuState = NakedMenuState(
@@ -308,17 +315,21 @@ class _NakedMenuState<T> extends State<NakedMenu<T>>
           isOpen: _isOpen,
         );
 
-        return NakedStateScopeBuilder(
+        final trigger = NakedStateScopeBuilder(
           value: menuState,
           child: widget.child,
           builder: widget.builder,
         );
+
+        return widget.semanticLabel == null
+            ? trigger
+            : ExcludeSemantics(child: trigger);
       },
     );
 
     Widget menuChild = widget.excludeSemantics
-        ? button
-        : Semantics(toggled: _isOpen, child: button);
+        ? ExcludeSemantics(child: button)
+        : Semantics(expanded: _isOpen, child: button);
 
     return AnchoredOverlayShell(
       controller: widget.controller,

--- a/packages/naked_ui/lib/src/naked_radio.dart
+++ b/packages/naked_ui/lib/src/naked_radio.dart
@@ -80,6 +80,7 @@ class NakedRadio<T> extends StatefulWidget {
     this.onPressChange,
     this.builder,
     this.groupRegistry,
+    this.semanticLabel,
   }) : assert(
          child != null || builder != null,
          'Either child or builder must be provided',
@@ -123,6 +124,9 @@ class NakedRadio<T> extends StatefulWidget {
   /// When null, the nearest [RadioGroup] ancestor is used.
   final RadioGroupRegistry<T>? groupRegistry;
 
+  /// Semantic label for assistive technologies.
+  final String? semanticLabel;
+
   @override
   State<NakedRadio<T>> createState() => _NakedRadioState<T>();
 }
@@ -164,7 +168,7 @@ class _NakedRadioState<T> extends State<NakedRadio<T>>
         widget.mouseCursor ??
         (widget.enabled ? SystemMouseCursors.click : SystemMouseCursors.basic);
 
-    return RawRadio<T>(
+    final radio = RawRadio<T>(
       value: widget.value,
       mouseCursor: WidgetStateMouseCursor.resolveWith((_) => effectiveCursor),
       toggleable: widget.toggleable,
@@ -207,14 +211,24 @@ class _NakedRadioState<T> extends State<NakedRadio<T>>
 
         // Ensure the area is hit-testable so RawRadio's GestureDetector
         // can receive taps even if the built widget has no gesture handlers.
-        return HitTestableContainer(
+        Widget radioChild = HitTestableContainer(
           child: NakedStateScopeBuilder(
             value: radioStateTyped,
             child: widget.child,
             builder: widget.builder,
           ),
         );
+
+        if (widget.semanticLabel != null) {
+          radioChild = ExcludeSemantics(child: radioChild);
+        }
+
+        return radioChild;
       },
     );
+
+    return widget.semanticLabel == null
+        ? radio
+        : Semantics(label: widget.semanticLabel, child: radio);
   }
 }

--- a/packages/naked_ui/lib/src/naked_select.dart
+++ b/packages/naked_ui/lib/src/naked_select.dart
@@ -409,6 +409,7 @@ class _NakedSelectState<T> extends State<NakedSelect<T>>
         onPressed: widget.enabled ? _toggle : null,
         enabled: widget.enabled,
         focusNode: widget.triggerFocusNode,
+        excludeSemantics: true,
         child: widget.child,
         builder: (context, buttonState, child) {
           final selectState = NakedSelectState(
@@ -426,18 +427,24 @@ class _NakedSelectState<T> extends State<NakedSelect<T>>
       ),
     );
 
-    Widget result = widget.excludeSemantics
+    final Widget semanticsChild = widget.semanticLabel == null
         ? selectWidget
-        : Semantics(
-            container: true,
-            enabled: widget.enabled,
-            button: true,
-            focusable: true,
-            expanded: _isOpen,
-            label: widget.semanticLabel,
-            value: semanticsValue,
-            onTap: widget.enabled ? _toggle : null,
-            child: selectWidget,
+        : ExcludeSemantics(child: selectWidget);
+
+    Widget result = widget.excludeSemantics
+        ? ExcludeSemantics(child: selectWidget)
+        : MergeSemantics(
+            child: Semantics(
+              container: true,
+              enabled: widget.enabled,
+              button: true,
+              focusable: true,
+              expanded: _isOpen,
+              label: widget.semanticLabel,
+              value: semanticsValue,
+              onTap: widget.enabled ? _toggle : null,
+              child: semanticsChild,
+            ),
           );
 
     return Shortcuts(

--- a/packages/naked_ui/lib/src/naked_select.dart
+++ b/packages/naked_ui/lib/src/naked_select.dart
@@ -330,6 +330,7 @@ class _NakedSelectState<T> extends State<NakedSelect<T>>
 
   void _handleOpen() {
     handleOpen(widget.onOpen);
+    if (mounted) setState(() {});
   }
 
   void _handleClose() {
@@ -338,6 +339,7 @@ class _NakedSelectState<T> extends State<NakedSelect<T>>
       onCanceled: widget.onCanceled,
       triggerFocusNode: widget.triggerFocusNode,
     );
+    if (mounted) setState(() {});
   }
 
   void _handleSelection(T? value) {

--- a/packages/naked_ui/lib/src/naked_slider.dart
+++ b/packages/naked_ui/lib/src/naked_slider.dart
@@ -6,6 +6,9 @@ import 'utilities/naked_focusable_detector.dart';
 import 'utilities/naked_state_scope.dart';
 import 'utilities/state.dart';
 
+/// Formats slider values for assistive technologies.
+typedef NakedSliderSemanticFormatterCallback = String Function(double value);
+
 /// Immutable view passed to [NakedSlider.builder].
 class NakedSliderState extends NakedState {
   /// The current slider value.
@@ -118,6 +121,7 @@ class NakedSlider extends StatefulWidget {
     this.keyboardStep = 0.01,
     this.largeKeyboardStep = 0.1,
     this.semanticLabel,
+    this.semanticFormatterCallback,
     this.excludeSemantics = false,
   }) : assert(min < max, 'min must be less than max'),
        assert(
@@ -188,6 +192,9 @@ class NakedSlider extends StatefulWidget {
   /// Semantic label for assistive technologies.
   final String? semanticLabel;
 
+  /// Formats semantic value announcements.
+  final NakedSliderSemanticFormatterCallback? semanticFormatterCallback;
+
   /// Whether to exclude this widget from the semantic tree.
   ///
   /// When true, the widget and its children are hidden from accessibility services.
@@ -252,6 +259,11 @@ class _NakedSliderState extends State<NakedSlider>
     final pct = (((v - widget.min) / total) * 100).round();
 
     return '$pct%';
+  }
+
+  String _semanticValueString(double value) {
+    final formatter = widget.semanticFormatterCallback;
+    return formatter == null ? _percentString(value) : formatter(value);
   }
 
   void _handleDragStart(DragStartDetails details) {
@@ -436,11 +448,11 @@ class _NakedSliderState extends State<NakedSlider>
               focusable: _isEnabled,
               focused: _isEnabled ? isFocused : null,
               label: widget.semanticLabel,
-              value: _percentString(widget.value),
-              increasedValue: _percentString(
+              value: _semanticValueString(widget.value),
+              increasedValue: _semanticValueString(
                 _normalizeValue(widget.value + _calculateStep(false)),
               ),
-              decreasedValue: _percentString(
+              decreasedValue: _semanticValueString(
                 _normalizeValue(widget.value - _calculateStep(false)),
               ),
               onIncrease: _isEnabled

--- a/packages/naked_ui/lib/src/naked_textfield.dart
+++ b/packages/naked_ui/lib/src/naked_textfield.dart
@@ -168,6 +168,7 @@ class NakedTextField extends StatefulWidget {
     this.ignorePointers,
     this.semanticLabel,
     this.semanticHint,
+    this.semanticErrorText,
     this.strutStyle,
     this.excludeSemantics = false,
   }) : assert(obscuringCharacter.length == 1),
@@ -352,6 +353,7 @@ class NakedTextField extends StatefulWidget {
   /// Semantics
   final String? semanticLabel;
   final String? semanticHint;
+  final String? semanticErrorText;
 
   /// Whether to exclude this widget from the semantic tree.
   ///
@@ -781,25 +783,40 @@ class _NakedTextFieldState extends State<NakedTextField>
       }
     }
 
+    String? _semanticHint() {
+      final errorText = widget.error ? widget.semanticErrorText : null;
+      if (widget.semanticHint == null || widget.semanticHint!.isEmpty) {
+        return errorText;
+      }
+      if (errorText == null || errorText.isEmpty) {
+        return widget.semanticHint;
+      }
+
+      return '${widget.semanticHint}\n$errorText';
+    }
+
     Widget withSemantics(Widget child) {
       return widget.excludeSemantics
           ? child
-          : Semantics(
-              container: true,
-              enabled: widget.enabled,
-              textField: true,
-              readOnly: widget.readOnly || !widget.enabled,
-              focusable: widget.enabled,
-              focused: widget.enabled ? focusNode.hasFocus : null,
-              obscured: widget.obscureText,
-              multiline: (widget.maxLines ?? 1) > 1,
-              maxValueLength: widget.maxLength,
-              currentValueLength: controller.text.length,
-              label: widget.semanticLabel,
-              value: widget.obscureText ? null : controller.text,
-              hint: widget.semanticHint,
-              onTap: (widget.enabled && !widget.readOnly) ? _semanticTap : null,
-              child: child,
+          : MergeSemantics(
+              child: Semantics(
+                enabled: widget.enabled,
+                liveRegion: widget.error && widget.semanticErrorText != null,
+                readOnly: widget.readOnly || !widget.enabled,
+                focusable: widget.enabled,
+                focused: widget.enabled ? focusNode.hasFocus : null,
+                obscured: widget.obscureText,
+                multiline: (widget.maxLines ?? 1) > 1,
+                maxValueLength: widget.maxLength,
+                currentValueLength: controller.text.length,
+                label: widget.semanticLabel,
+                value: widget.obscureText ? null : controller.text,
+                hint: _semanticHint(),
+                onTap: (widget.enabled && !widget.readOnly)
+                    ? _semanticTap
+                    : null,
+                child: child,
+              ),
             );
     }
 

--- a/packages/naked_ui/lib/src/naked_tooltip.dart
+++ b/packages/naked_ui/lib/src/naked_tooltip.dart
@@ -112,6 +112,9 @@ class NakedTooltip extends StatefulWidget {
   final RawMenuAnchorOverlayBuilder overlayBuilder;
 
   /// The semantic label for screen readers.
+  ///
+  /// When null, the trigger keeps its own accessible name, but no tooltip
+  /// semantic text is exposed.
   final String? semanticsLabel;
 
   /// Positioning configuration for the overlay.

--- a/packages/naked_ui/test/exclude_semantics_test.dart
+++ b/packages/naked_ui/test/exclude_semantics_test.dart
@@ -1,6 +1,11 @@
+import 'dart:ui' show Tristate;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
+
+import 'semantics/semantics_test_utils.dart';
 
 void main() {
   group('excludeSemantics', () {
@@ -244,6 +249,56 @@ void main() {
       );
 
       expect(find.bySemanticsLabel(RegExp(r'Test Dialog')), findsNothing);
+
+      semanticsHandle.dispose();
+    });
+
+    testWidgets('NakedMenu respects excludeSemantics', (tester) async {
+      final semanticsHandle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NakedMenu<String>(
+              controller: MenuController(),
+              semanticLabel: 'Test Menu',
+              builder: (context, state, child) => const Text('Menu'),
+              overlayBuilder: (context, info) => const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel(RegExp(r'Test Menu')), findsOneWidget);
+      expect(find.bySemanticsLabel('Menu'), findsNothing);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NakedMenu<String>(
+              controller: MenuController(),
+              semanticLabel: 'Test Menu',
+              excludeSemantics: true,
+              builder: (context, state, child) => const Text('Menu'),
+              overlayBuilder: (context, info) => const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel(RegExp(r'Test Menu')), findsNothing);
+      expect(find.bySemanticsLabel('Menu'), findsNothing);
+
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final leakedTriggerNodes = collectSemanticsNodes(root, (node) {
+        final data = node.getSemanticsData();
+        return data.label.contains('Test Menu') ||
+            data.label.contains('Menu') ||
+            data.flagsCollection.isButton ||
+            data.flagsCollection.isExpanded != Tristate.none ||
+            data.hasAction(SemanticsAction.tap);
+      });
+      expect(leakedTriggerNodes, isEmpty);
 
       semanticsHandle.dispose();
     });

--- a/packages/naked_ui/test/semantics/naked_accordion_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_accordion_semantics_test.dart
@@ -15,26 +15,114 @@ void main() {
   }
 
   group('NakedAccordion Semantics', () {
-    testWidgets('collapsed strict parity vs ExpansionTile', (tester) async {
+    testWidgets('header uses visible text when semanticLabel is omitted', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
 
       await tester.pumpWidget(
         _buildTestApp(
-          Material(
-            child: ListView(
-              shrinkWrap: true,
-              children: const [
-                ExpansionTile(title: Text('Header'), children: [Text('Body')]),
-              ],
+          NakedAccordionGroup<String>(
+            controller: NakedAccordionController<String>(),
+            child: NakedAccordion<String>(
+              value: 'item',
+              builder: (context, itemState) => const Text('Visible Header'),
+              child: const Text('Body'),
             ),
           ),
         ),
       );
 
-      final mNode = tester.getSemantics(find.text('Header'));
-      final strict = buildStrictMatcherFromSemanticsData(
-        mNode.getSemanticsData(),
+      expect(
+        tester.getSemantics(find.text('Visible Header')),
+        matchesSemantics(
+          label: 'Visible Header',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: false,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
       );
+
+      handle.dispose();
+    });
+
+    testWidgets('semanticLabel overrides visible header text', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedAccordionGroup<String>(
+            controller: NakedAccordionController<String>(),
+            child: NakedAccordion<String>(
+              value: 'item',
+              semanticLabel: 'Semantic Header',
+              builder: (context, itemState) => const Text('Visible Header'),
+              child: const Text('Body'),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.text('Visible Header')),
+        matchesSemantics(
+          label: 'Semantic Header',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: false,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('excludeSemantics hides visible header fallback', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedAccordionGroup<String>(
+            controller: NakedAccordionController<String>(),
+            child: NakedAccordion<String>(
+              value: 'item',
+              excludeSemantics: true,
+              builder: (context, itemState) => const Text('Visible Header'),
+              child: const Text('Body'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Visible Header'), findsNothing);
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final leakedTriggerNodes = collectSemanticsNodes(root, (node) {
+        final data = node.getSemanticsData();
+        return data.label.contains('Visible Header') ||
+            data.flagsCollection.isButton ||
+            data.flagsCollection.isExpanded != Tristate.none ||
+            data.hasAction(SemanticsAction.tap);
+      });
+      expect(leakedTriggerNodes, isEmpty);
+
+      handle.dispose();
+    });
+
+    testWidgets('collapsed header exposes explicit disclosure contract', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
 
       await tester.pumpWidget(
         _buildTestApp(
@@ -54,7 +142,20 @@ void main() {
         ),
       );
       // Use label to target the header semantics node.
-      expect(tester.getSemantics(find.text('Header')), strict);
+      expect(
+        tester.getSemantics(find.text('Header')),
+        matchesSemantics(
+          label: 'Header',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: false,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
 
       handle.dispose();
     });
@@ -91,6 +192,8 @@ void main() {
       // Core semantic properties should match Material patterns
       expect(headerData.hasAction(SemanticsAction.tap), isTrue);
       expect(headerData.hasAction(SemanticsAction.focus), isTrue);
+      expect(headerData.flagsCollection.isButton, isTrue);
+      expect(headerData.flagsCollection.isExpanded, Tristate.isTrue);
       expect(headerData.flagsCollection.isFocused != Tristate.none, isTrue);
       expect(headerData.flagsCollection.isEnabled != Tristate.none, isTrue);
       expect(headerData.flagsCollection.isEnabled == Tristate.isTrue, isTrue);

--- a/packages/naked_ui/test/semantics/naked_dialog_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_dialog_semantics_test.dart
@@ -183,6 +183,30 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('modal dialog exposes route scope and route name', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await _showNakedDialog(
+        tester,
+        title: 'Route Dialog',
+        content: 'This dialog is a route scope',
+      );
+
+      final dialogRoot = tester.getSemantics(find.byType(NakedDialog));
+      final routeNode = findSemanticsNode(dialogRoot, (node) {
+        final data = node.getSemanticsData();
+        return data.label == 'Route Dialog' &&
+            data.flagsCollection.scopesRoute &&
+            data.flagsCollection.namesRoute;
+      });
+
+      expect(routeNode, isNotNull);
+
+      handle.dispose();
+    });
+
     testWidgets('modal vs non-modal semantics', (tester) async {
       final handle = tester.ensureSemantics();
 

--- a/packages/naked_ui/test/semantics/naked_menu_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_menu_semantics_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Tristate;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
@@ -63,6 +65,75 @@ void main() {
       expect(summary.flags.contains('isButton'), isTrue);
       expect(summary.flags.contains('isFocusable'), isTrue);
       expect(summary.actions.contains('tap'), isTrue);
+
+      handle.dispose();
+    });
+
+    testWidgets('trigger exposes expanded state instead of toggled', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(_buildTestApp(_buildNakedMenu()));
+
+      var triggerData = tester
+          .getSemantics(find.text('Show Menu'))
+          .getSemanticsData();
+      expect(triggerData.flagsCollection.isExpanded, Tristate.isFalse);
+      expect(triggerData.flagsCollection.isToggled, Tristate.none);
+
+      await tester.tap(find.text('Show Menu'));
+      await tester.pumpAndSettle();
+
+      triggerData = tester
+          .getSemantics(find.text('Show Menu'))
+          .getSemanticsData();
+      expect(triggerData.flagsCollection.isExpanded, Tristate.isTrue);
+      expect(triggerData.flagsCollection.isToggled, Tristate.none);
+
+      await tester.tap(find.text('Show Menu'));
+      await tester.pumpAndSettle();
+
+      triggerData = tester
+          .getSemantics(find.text('Show Menu'))
+          .getSemanticsData();
+      expect(triggerData.flagsCollection.isExpanded, Tristate.isFalse);
+      expect(triggerData.flagsCollection.isToggled, Tristate.none);
+
+      handle.dispose();
+    });
+
+    testWidgets('trigger semanticLabel overrides visible trigger text', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final controller = MenuController();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedMenu<String>(
+            controller: controller,
+            semanticLabel: 'Application menu',
+            builder: (context, state, child) => const Text('File'),
+            overlayBuilder: (context, info) => const SizedBox.shrink(),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.text('File')),
+        matchesSemantics(
+          label: 'Application menu',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: false,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
 
       handle.dispose();
     });
@@ -139,13 +210,17 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
-      // Check enabled item semantics
-      final enabledSummary = summarizeMergedFromRoot(
-        tester,
-        control: ControlType.button,
-      );
-      expect(enabledSummary.flags.contains('isEnabled'), isTrue);
-      expect(enabledSummary.actions.contains('tap'), isTrue);
+      final enabledData = tester
+          .getSemantics(find.text('Enabled Item'))
+          .getSemanticsData();
+      expect(enabledData.flagsCollection.isEnabled, Tristate.isTrue);
+      expect(enabledData.hasAction(SemanticsAction.tap), isTrue);
+
+      final disabledData = tester
+          .getSemantics(find.text('Disabled Item'))
+          .getSemanticsData();
+      expect(disabledData.flagsCollection.isEnabled, Tristate.isFalse);
+      expect(disabledData.hasAction(SemanticsAction.tap), isFalse);
 
       handle.dispose();
     });
@@ -311,8 +386,47 @@ void main() {
       await tester.tap(find.text('Labeled Menu'));
       await tester.pumpAndSettle();
 
-      // Verify semantic label is applied
-      expect(find.text('Save'), findsOneWidget);
+      final saveData = tester
+          .getSemantics(find.text('Save'))
+          .getSemanticsData();
+      expect(saveData.label, contains('Save document'));
+      expect(saveData.hasAction(SemanticsAction.tap), isTrue);
+
+      handle.dispose();
+    });
+
+    testWidgets('controller changes update trigger expanded semantics', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final controller = MenuController();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedMenu<String>(
+            controller: controller,
+            builder: (context, state, child) => const Text('Menu trigger'),
+            overlayBuilder: (context, info) => const SizedBox.shrink(),
+          ),
+        ),
+      );
+
+      var data = tester
+          .getSemantics(find.text('Menu trigger'))
+          .getSemanticsData();
+      expect(data.flagsCollection.isExpanded, Tristate.isFalse);
+
+      controller.open();
+      await tester.pumpAndSettle();
+
+      data = tester.getSemantics(find.text('Menu trigger')).getSemanticsData();
+      expect(data.flagsCollection.isExpanded, Tristate.isTrue);
+
+      controller.close();
+      await tester.pumpAndSettle();
+
+      data = tester.getSemantics(find.text('Menu trigger')).getSemanticsData();
+      expect(data.flagsCollection.isExpanded, Tristate.isFalse);
 
       handle.dispose();
     });

--- a/packages/naked_ui/test/semantics/naked_radio_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_radio_semantics_test.dart
@@ -192,5 +192,64 @@ void main() {
 
       handle.dispose();
     });
+
+    testWidgets(
+      'semanticLabel overrides visible child label and preserves radio semantics',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        final reg = _FakeRegistry<String>('a');
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            NakedRadio<String>(
+              value: 'a',
+              groupRegistry: reg,
+              semanticLabel: 'Option A',
+              child: const Text('Visible A'),
+            ),
+          ),
+        );
+
+        final node = _findRadioNode(tester);
+        expect(
+          node,
+          matchesSemantics(
+            label: 'Option A',
+            hasCheckedState: true,
+            isChecked: true,
+            hasEnabledState: true,
+            isEnabled: true,
+            isFocusable: true,
+            isInMutuallyExclusiveGroup: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+          ),
+        );
+        expect(node.getSemanticsData().label, isNot(contains('Visible A')));
+
+        handle.dispose();
+      },
+    );
+
+    testWidgets('visible child labels radio when semanticLabel is omitted', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final reg = _FakeRegistry<String>('a');
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedRadio<String>(
+            value: 'a',
+            groupRegistry: reg,
+            child: const Text('Visible A'),
+          ),
+        ),
+      );
+
+      expect(_findRadioNode(tester).getSemanticsData().label, 'Visible A');
+
+      handle.dispose();
+    });
   });
 }

--- a/packages/naked_ui/test/semantics/naked_select_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_select_semantics_test.dart
@@ -73,9 +73,22 @@ void main() {
 
       await tester.pumpWidget(_buildTestApp(_buildNakedSelect()));
 
+      Tristate triggerExpanded() {
+        final root = tester.getSemantics(find.byType(Scaffold));
+        final trigger = collectSemanticsNodes(
+          root,
+          (node) =>
+              node.getSemanticsData().flagsCollection.isExpanded !=
+              Tristate.none,
+        ).single;
+
+        return trigger.getSemanticsData().flagsCollection.isExpanded;
+      }
+
       // Initially closed
       expect(find.text('Select Option'), findsOneWidget);
       expect(find.text('Option 1'), findsNothing);
+      expect(triggerExpanded(), Tristate.isFalse);
 
       // Tap to open
       await tester.tap(find.text('Select Option'));
@@ -85,6 +98,8 @@ void main() {
       expect(find.text('Option 1'), findsOneWidget);
       expect(find.text('Option 2'), findsOneWidget);
       expect(find.text('Option 3'), findsOneWidget);
+      // Trigger must report the open state to screen readers.
+      expect(triggerExpanded(), Tristate.isTrue);
 
       // Tap outside to close
       await tester.tapAt(const Offset(10, 10));
@@ -92,6 +107,7 @@ void main() {
 
       // Verify select menu is closed
       expect(find.text('Option 1'), findsNothing);
+      expect(triggerExpanded(), Tristate.isFalse);
 
       handle.dispose();
     });

--- a/packages/naked_ui/test/semantics/naked_select_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_select_semantics_test.dart
@@ -60,6 +60,7 @@ void main() {
         tester,
         control: ControlType.button,
       );
+      expect(summary.label, 'Select Option');
       expect(summary.flags.contains('isButton'), isTrue);
       expect(summary.flags.contains('isFocusable'), isTrue);
       expect(summary.actions.contains('tap'), isTrue);
@@ -160,16 +161,17 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
 
-      // Verify trigger has keyboard semantics
-      final triggerSemantics = tester.getSemantics(find.text('Select option'));
-      expect(
-        triggerSemantics.getSemanticsData().hasAction(SemanticsAction.tap),
-        isTrue,
-      );
-      expect(
-        triggerSemantics.getSemanticsData().flagsCollection.isFocused,
-        Tristate.isTrue,
-      );
+      // Verify trigger has keyboard semantics.
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final triggerSemantics = findSemanticsNode(root, (node) {
+        final data = node.getSemanticsData();
+        return data.label == 'Select option' &&
+            data.flagsCollection.isExpanded != Tristate.none;
+      });
+      expect(triggerSemantics, isNotNull);
+      final triggerData = triggerSemantics!.getSemanticsData();
+      expect(triggerData.hasAction(SemanticsAction.tap), isTrue);
+      expect(triggerData.flagsCollection.isFocused, Tristate.isTrue);
 
       // Open with keyboard
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
@@ -277,6 +279,50 @@ void main() {
 
       // Verify select with semantic label
       expect(find.text('Labeled Select'), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets('select trigger exposes one semantic control node', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedSelect<String>(
+            value: 'option1',
+            onChanged: (value) {},
+            semanticLabel: 'Choose an option',
+            builder: (context, state, child) => const Text('Labeled Select'),
+            overlayBuilder: (context, info) => const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                NakedSelectOption(value: 'option1', child: Text('Option 1')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      bool isTriggerControl(SemanticsNode node) {
+        final data = node.getSemanticsData();
+        return data.flagsCollection.isButton ||
+            data.flagsCollection.isExpanded != Tristate.none ||
+            data.hasAction(SemanticsAction.tap);
+      }
+
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final controls = collectSemanticsNodes(root, isTriggerControl);
+      expect(controls, hasLength(1));
+
+      final data = controls.single.getSemanticsData();
+      expect(data.label, 'Choose an option');
+      expect(data.label, isNot(contains('Labeled Select')));
+      expect(data.value, 'option1');
+      expect(data.flagsCollection.isButton, isTrue);
+      expect(data.flagsCollection.isExpanded, Tristate.isFalse);
+      expect(data.hasAction(SemanticsAction.tap), isTrue);
 
       handle.dispose();
     });

--- a/packages/naked_ui/test/semantics/naked_slider_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_slider_semantics_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,15 +15,13 @@ void main() {
   }
 
   group('NakedSlider Semantics', () {
-    testWidgets('parity with Material Slider - enabled', (tester) async {
+    testWidgets('enabled slider exposes value and keyboard step semantics', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
 
-      await expectSemanticsParity(
-        tester: tester,
-        material: _buildTestApp(
-          Slider(value: 0.5, min: 0, max: 1, onChanged: (_) {}),
-        ),
-        naked: _buildTestApp(
+      await tester.pumpWidget(
+        _buildTestApp(
           NakedSlider(
             value: 0.5,
             min: 0,
@@ -30,20 +30,29 @@ void main() {
             child: const SizedBox(width: 200, height: 40),
           ),
         ),
+      );
+
+      final summary = summarizeMergedFromRoot(
+        tester,
         control: ControlType.slider,
       );
+      expect(summary.value, '50%');
+      expect(summary.increasedValue, '51%');
+      expect(summary.decreasedValue, '49%');
+      expect(summary.flags, containsAll(['isSlider', 'hasEnabledState']));
+      expect(summary.flags, contains('isEnabled'));
+      expect(summary.actions, containsAll(['increase', 'decrease']));
+
       handle.dispose();
     });
 
-    testWidgets('parity with Material Slider - disabled', (tester) async {
+    testWidgets('disabled slider exposes value without semantic actions', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
 
-      await expectSemanticsParity(
-        tester: tester,
-        material: _buildTestApp(
-          const Slider(value: 0.5, min: 0, max: 1, onChanged: null),
-        ),
-        naked: _buildTestApp(
+      await tester.pumpWidget(
+        _buildTestApp(
           NakedSlider(
             value: 0.5,
             min: 0,
@@ -52,8 +61,17 @@ void main() {
             child: const SizedBox(width: 200, height: 40),
           ),
         ),
+      );
+
+      final summary = summarizeMergedFromRoot(
+        tester,
         control: ControlType.slider,
       );
+      expect(summary.value, '50%');
+      expect(summary.flags, contains('isSlider'));
+      expect(summary.flags, isNot(contains('isEnabled')));
+      expect(summary.actions, isEmpty);
+
       handle.dispose();
     });
 
@@ -93,7 +111,10 @@ void main() {
         control: ControlType.slider,
       );
 
-      expect(nakedFocused, equals(materialFocused));
+      expect(nakedFocused.label, materialFocused.label);
+      expect(nakedFocused.value, materialFocused.value);
+      expect(nakedFocused.flags, materialFocused.flags);
+      expect(nakedFocused.actions, materialFocused.actions);
 
       fm.dispose();
       fn.dispose();
@@ -134,8 +155,112 @@ void main() {
         control: ControlType.slider,
       );
 
-      expect(nakedHovered, equals(materialHovered));
+      expect(nakedHovered.label, materialHovered.label);
+      expect(nakedHovered.value, materialHovered.value);
+      expect(nakedHovered.flags, materialHovered.flags);
+      expect(nakedHovered.actions, materialHovered.actions);
       await mouse.removePointer();
+      handle.dispose();
+    });
+
+    testWidgets('semanticFormatterCallback customizes value announcements', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedSlider(
+            value: 50,
+            min: 0,
+            max: 100,
+            keyboardStep: 10,
+            semanticFormatterCallback: (value) => '${value.round()} dollars',
+            onChanged: (_) {},
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        ),
+      );
+
+      final summary = summarizeMergedFromRoot(
+        tester,
+        control: ControlType.slider,
+      );
+      expect(summary.value, '50 dollars');
+      expect(summary.increasedValue, '60 dollars');
+      expect(summary.decreasedValue, '40 dollars');
+
+      handle.dispose();
+    });
+
+    testWidgets('semantic increase and decrease actions step and clamp value', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final reportedValues = <double>[];
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedSlider(
+            value: 0.5,
+            min: 0,
+            max: 1,
+            keyboardStep: 0.1,
+            onChanged: reportedValues.add,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        ),
+      );
+
+      var root = tester.getSemantics(find.byType(Scaffold));
+      var sliderNode = findSemanticsNode(
+        root,
+        (node) => node.getSemanticsData().flagsCollection.isSlider,
+      );
+      expect(sliderNode, isNotNull);
+
+      void performSliderAction(ui.SemanticsAction action) {
+        tester.binding.performSemanticsAction(
+          ui.SemanticsActionEvent(
+            type: action,
+            viewId: tester.view.viewId,
+            nodeId: sliderNode!.id,
+          ),
+        );
+      }
+
+      performSliderAction(ui.SemanticsAction.increase);
+      await tester.pump();
+      performSliderAction(ui.SemanticsAction.decrease);
+      await tester.pump();
+
+      expect(reportedValues, [closeTo(0.6, 0.0001), closeTo(0.4, 0.0001)]);
+
+      reportedValues.clear();
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedSlider(
+            value: 0.95,
+            min: 0,
+            max: 1,
+            keyboardStep: 0.1,
+            onChanged: reportedValues.add,
+            child: const SizedBox(width: 200, height: 40),
+          ),
+        ),
+      );
+      root = tester.getSemantics(find.byType(Scaffold));
+      sliderNode = findSemanticsNode(
+        root,
+        (node) => node.getSemanticsData().flagsCollection.isSlider,
+      );
+      expect(sliderNode, isNotNull);
+
+      performSliderAction(ui.SemanticsAction.increase);
+      await tester.pump();
+
+      expect(reportedValues, [1.0]);
+
       handle.dispose();
     });
   });

--- a/packages/naked_ui/test/semantics/naked_tabs_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tabs_semantics_test.dart
@@ -1,37 +1,14 @@
+import 'dart:ui' show Tristate;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
 
 import 'semantics_test_utils.dart';
 
 void main() {
-  Widget _buildMaterialTabs({required int initialIndex}) {
-    return MaterialApp(
-      home: DefaultTabController(
-        length: 2,
-        initialIndex: initialIndex,
-        child: Scaffold(
-          appBar: AppBar(
-            title: const Text('Tabs'),
-            bottom: const TabBar(
-              tabs: [
-                Tab(text: 'A'),
-                Tab(text: 'B'),
-              ],
-            ),
-          ),
-          body: const TabBarView(
-            children: [
-              Center(child: Text('A body')),
-              Center(child: Text('B body')),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   Widget _buildNakedTabs({required String selected}) {
     return MaterialApp(
       home: Scaffold(
@@ -64,60 +41,58 @@ void main() {
   }
 
   group('NakedTab Semantics', () {
-    testWidgets('parity when first tab selected', (tester) async {
+    testWidgets('first tab exposes explicit selected button contract', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
-      await expectSemanticsParity(
-        tester: tester,
-        material: _buildMaterialTabs(initialIndex: 0),
-        naked: _buildNakedTabs(selected: 'A'),
-        control: ControlType.tab,
-      );
+
+      await tester.pumpWidget(_buildNakedTabs(selected: 'A'));
+
+      final summary = summarizeMergedFromRoot(tester, control: ControlType.tab);
+      expect(summary.label, 'A');
+      expect(summary.flags, containsAll(['isButton', 'isSelected']));
+      expect(summary.flags, containsAll(['hasEnabledState', 'isEnabled']));
+      expect(summary.actions, contains('tap'));
+
       handle.dispose();
     });
 
-    testWidgets('parity when second tab selected', (tester) async {
+    testWidgets('second tab exposes explicit selected button contract', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
-      await expectSemanticsParity(
-        tester: tester,
-        material: _buildMaterialTabs(initialIndex: 1),
-        naked: _buildNakedTabs(selected: 'B'),
-        control: ControlType.tab,
-      );
+
+      await tester.pumpWidget(_buildNakedTabs(selected: 'B'));
+
+      final tabB = tester.getSemantics(find.text('B'));
+      final data = tabB.getSemanticsData();
+      expect(data.label, 'B');
+      expect(data.flagsCollection.isButton, isTrue);
+      expect(data.flagsCollection.isSelected, Tristate.isTrue);
+      expect(data.flagsCollection.isEnabled, Tristate.isTrue);
+      expect(data.hasAction(SemanticsAction.tap), isTrue);
+
       handle.dispose();
     });
 
-    testWidgets('hover parity on first tab', (tester) async {
+    testWidgets('hovered selected tab keeps selected button contract', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
       final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await mouse.addPointer();
       await tester.pump();
 
-      // Material hovered
-      await tester.pumpWidget(_buildMaterialTabs(initialIndex: 0));
-      // Hover over first tab labeled 'A'
-      await mouse.moveTo(tester.getCenter(find.text('A').first));
-      await tester.pump();
-      final mat = summarizeMergedFromRoot(tester, control: ControlType.tab);
-
-      // Naked hovered
       await tester.pumpWidget(_buildNakedTabs(selected: 'A'));
       await mouse.moveTo(tester.getCenter(find.text('A').first));
       await tester.pump();
       final nak = summarizeMergedFromRoot(tester, control: ControlType.tab);
 
-      SemanticsSummary normalize(SemanticsSummary s) => SemanticsSummary(
-        label: s.label,
-        value: s.value,
-        flags: s.flags
-            .where(
-              (f) =>
-                  f != 'isButton' && f != 'isEnabled' && f != 'hasEnabledState',
-            )
-            .toSet(),
-        actions: s.actions,
-      );
+      expect(nak.label, 'A');
+      expect(nak.flags, contains('isButton'));
+      expect(nak.flags, contains('isSelected'));
+      expect(nak.actions, contains('tap'));
 
-      expect(normalize(nak), equals(normalize(mat)));
       await mouse.removePointer();
       handle.dispose();
     });

--- a/packages/naked_ui/test/semantics/naked_textfield_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_textfield_semantics_test.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/gestures.dart';
+import 'dart:ui' show Tristate;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
 
 import 'semantics_test_utils.dart';
-
-// Removed unused helper and unneeded rendering import.
 
 void main() {
   Widget _buildTestApp(Widget child) {
@@ -15,59 +14,62 @@ void main() {
   }
 
   group('NakedTextField Semantics', () {
-    testWidgets('parity with Material TextField - enabled empty', (
+    testWidgets('enabled empty field exposes text-field contract', (
       tester,
     ) async {
       final handle = tester.ensureSemantics();
 
-      await expectSemanticsParity(
-        tester: tester,
-        material: _buildTestApp(const TextField()),
-        naked: _buildTestApp(
+      await tester.pumpWidget(
+        _buildTestApp(
           NakedTextField(
             enabled: true,
             builder: (context, state, editable) => editable,
           ),
         ),
+      );
+
+      final summary = summarizeMergedFromRoot(
+        tester,
         control: ControlType.textField,
       );
+      expect(summary.flags, containsAll(['isTextField', 'hasEnabledState']));
+      expect(summary.flags, contains('isEnabled'));
+      expect(summary.flags, contains('isFocusable'));
+      expect(summary.actions, contains('tap'));
+
       handle.dispose();
     });
 
-    testWidgets('parity with Material TextField - disabled', (tester) async {
+    testWidgets('disabled field exposes read-only disabled contract', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
 
-      await expectSemanticsParity(
-        tester: tester,
-        material: _buildTestApp(const TextField(enabled: false)),
-        naked: _buildTestApp(
+      await tester.pumpWidget(
+        _buildTestApp(
           NakedTextField(
             enabled: false,
             builder: (context, state, editable) => editable,
           ),
         ),
-        control: ControlType.textField,
       );
-      handle.dispose();
-    });
 
-    testWidgets('focus and hover parity', (tester) async {
-      final handle = tester.ensureSemantics();
-      final fm = FocusNode();
-      final fn = FocusNode();
-      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await mouse.addPointer();
-      await tester.pump();
-
-      await tester.pumpWidget(_buildTestApp(TextField(focusNode: fm)));
-      fm.requestFocus();
-      await tester.pump();
-      await mouse.moveTo(tester.getCenter(find.byType(TextField)));
-      await tester.pump();
-      var materialFocused = summarizeMergedFromRoot(
+      final summary = summarizeMergedFromRoot(
         tester,
         control: ControlType.textField,
       );
+      expect(summary.flags, contains('isTextField'));
+      expect(summary.flags, contains('hasEnabledState'));
+      expect(summary.flags, isNot(contains('isEnabled')));
+      expect(summary.flags, contains('isReadOnly'));
+      expect(summary.actions, isNot(contains('tap')));
+
+      handle.dispose();
+    });
+
+    testWidgets('focused field exposes focus semantics', (tester) async {
+      final handle = tester.ensureSemantics();
+      final fn = FocusNode();
 
       await tester.pumpWidget(
         _buildTestApp(
@@ -79,36 +81,23 @@ void main() {
       );
       fn.requestFocus();
       await tester.pump();
-      await mouse.moveTo(tester.getCenter(find.byType(NakedTextField)));
-      await tester.pump();
-      var nakedFocused = summarizeMergedFromRoot(
+      final summary = summarizeMergedFromRoot(
         tester,
         control: ControlType.textField,
       );
-      // Normalize focusable flag differences from ancestor placement.
-      SemanticsSummary stripFocusable(SemanticsSummary s) => SemanticsSummary(
-        label: s.label,
-        value: s.value,
-        flags: s.flags.where((f) => f != 'isFocusable').toSet(),
-        actions: s.actions,
-      );
-      materialFocused = stripFocusable(materialFocused);
-      nakedFocused = stripFocusable(nakedFocused);
-      expect(nakedFocused, equals(materialFocused));
+      expect(summary.flags, contains('isTextField'));
+      expect(summary.flags, contains('isFocused'));
+      expect(summary.flags, contains('isFocusable'));
+      expect(summary.actions, contains('focus'));
 
-      await mouse.removePointer();
-      fm.dispose();
       fn.dispose();
       handle.dispose();
     });
 
-    testWidgets('multiline and readOnly parity', (tester) async {
+    testWidgets('read-only multiline field exposes text-field flags', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
-
-      await tester.pumpWidget(
-        _buildTestApp(const TextField(maxLines: 3, readOnly: true)),
-      );
-      var mat = summarizeMergedFromRoot(tester, control: ControlType.textField);
 
       await tester.pumpWidget(
         _buildTestApp(
@@ -119,15 +108,90 @@ void main() {
           ),
         ),
       );
-      var nak = summarizeMergedFromRoot(tester, control: ControlType.textField);
-      // Normalize focusable differences
-      SemanticsSummary stripFocusable(SemanticsSummary s) => SemanticsSummary(
-        label: s.label,
-        value: s.value,
-        flags: s.flags.where((f) => f != 'isFocusable').toSet(),
-        actions: s.actions,
+      final summary = summarizeMergedFromRoot(
+        tester,
+        control: ControlType.textField,
       );
-      expect(stripFocusable(nak), equals(stripFocusable(mat)));
+      expect(summary.flags, contains('isTextField'));
+      expect(summary.flags, contains('isReadOnly'));
+      expect(summary.flags, contains('isMultiline'));
+
+      handle.dispose();
+    });
+
+    testWidgets('error text is associated with a live text field node', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final controller = TextEditingController(text: 'bad');
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedTextField(
+            controller: controller,
+            error: true,
+            semanticLabel: 'Email',
+            semanticHint: 'Enter your email',
+            semanticErrorText: 'Enter a valid email address',
+            builder: (context, state, editable) => editable,
+          ),
+        ),
+      );
+
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final textFieldNodes = collectSemanticsNodes(
+        root,
+        (node) => node.getSemanticsData().flagsCollection.isTextField,
+      );
+      expect(textFieldNodes, hasLength(1));
+      expectNoNestedSemanticsNodes(
+        root,
+        predicate: (node) =>
+            node.getSemanticsData().flagsCollection.isTextField,
+        debugName: 'text field',
+      );
+
+      final data = textFieldNodes.single.getSemanticsData();
+      expect(data.label, 'Email');
+      expect(data.hint, contains('Enter your email'));
+      expect(data.hint, contains('Enter a valid email address'));
+      expect(data.flagsCollection.isLiveRegion, isTrue);
+      expect(data.flagsCollection.isTextField, isTrue);
+      expect(data.flagsCollection.isFocused, isNot(Tristate.none));
+
+      controller.dispose();
+      handle.dispose();
+    });
+
+    testWidgets('semanticErrorText is silent when error is false', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          NakedTextField(
+            error: false,
+            semanticLabel: 'Email',
+            semanticHint: 'Enter your email',
+            semanticErrorText: 'Enter a valid email address',
+            builder: (context, state, editable) => editable,
+          ),
+        ),
+      );
+
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final node = findSemanticsNode(
+        root,
+        (node) => node.getSemanticsData().flagsCollection.isTextField,
+      );
+
+      expect(node, isNotNull);
+      final data = node!.getSemanticsData();
+      expect(data.label, 'Email');
+      expect(data.hint, 'Enter your email');
+      expect(data.hint, isNot(contains('Enter a valid email address')));
+      expect(data.flagsCollection.isLiveRegion, isFalse);
 
       handle.dispose();
     });

--- a/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
@@ -152,13 +152,9 @@ void main() {
         ),
       );
 
-      // Verify the widget renders properly
-      expect(find.text('Help'), findsOneWidget);
-
-      // Check that semantics are properly attached
-      final Element element = find.text('Help').evaluate().first;
-      final Widget widget = element.widget;
-      expect(widget, isA<Text>());
+      final data = tester.getSemantics(find.text('Help')).getSemanticsData();
+      expect(data.label, 'Help');
+      expect(data.tooltip, 'This is a helpful tooltip');
 
       handle.dispose();
     });
@@ -177,6 +173,14 @@ void main() {
 
       // Should still work without explicit semantics label
       expect(find.text('No label'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.text('No label')),
+        matchesSemantics(label: 'No label'),
+      );
+      expect(
+        tester.getSemantics(find.text('No label')).getSemanticsData().tooltip,
+        isEmpty,
+      );
 
       handle.dispose();
     });

--- a/packages/naked_ui/test/semantics/semantics_test_utils.dart
+++ b/packages/naked_ui/test/semantics/semantics_test_utils.dart
@@ -14,12 +14,18 @@ class SemanticsSummary {
   SemanticsSummary({
     required this.label,
     required this.value,
+    required this.increasedValue,
+    required this.decreasedValue,
+    required this.identifier,
     required this.flags,
     required this.actions,
   });
 
   final String? label;
   final String? value;
+  final String? increasedValue;
+  final String? decreasedValue;
+  final String? identifier;
   final Set<String> flags;
   final Set<String> actions;
 
@@ -29,6 +35,12 @@ class SemanticsSummary {
         (label ?? '') +
         ', value: ' +
         (value ?? '') +
+        ', increasedValue: ' +
+        (increasedValue ?? '') +
+        ', decreasedValue: ' +
+        (decreasedValue ?? '') +
+        ', identifier: ' +
+        (identifier ?? '') +
         ', flags: ' +
         flags.join(',') +
         ', actions: ' +
@@ -42,6 +54,9 @@ class SemanticsSummary {
     return other is SemanticsSummary &&
         other.label == label &&
         other.value == value &&
+        other.increasedValue == increasedValue &&
+        other.decreasedValue == decreasedValue &&
+        other.identifier == identifier &&
         other.flags.length == flags.length &&
         other.flags.containsAll(flags) &&
         other.actions.length == actions.length &&
@@ -49,7 +64,15 @@ class SemanticsSummary {
   }
 
   @override
-  int get hashCode => Object.hash(label, value, flags.length, actions.length);
+  int get hashCode => Object.hash(
+    label,
+    value,
+    increasedValue,
+    decreasedValue,
+    identifier,
+    flags.length,
+    actions.length,
+  );
 }
 
 /// Traverses semantics tree depth-first and returns the first node
@@ -72,6 +95,75 @@ SemanticsNode? findSemanticsNode(
 
   root.visitChildren(visitor);
   return found;
+}
+
+/// Traverses the semantics tree depth-first and returns every matching node.
+List<SemanticsNode> collectSemanticsNodes(
+  SemanticsNode root,
+  SemanticsPredicate predicate, {
+  bool includeMerged = false,
+}) {
+  final nodes = <SemanticsNode>[];
+
+  bool visitor(SemanticsNode node) {
+    if ((includeMerged || !node.isMergedIntoParent) && predicate(node)) {
+      nodes.add(node);
+    }
+    node.visitChildren(visitor);
+    return true;
+  }
+
+  visitor(root);
+  return nodes;
+}
+
+/// Counts every semantics node matching [predicate].
+int countSemanticsNodes(
+  SemanticsNode root,
+  SemanticsPredicate predicate, {
+  bool includeMerged = false,
+}) {
+  return collectSemanticsNodes(
+    root,
+    predicate,
+    includeMerged: includeMerged,
+  ).length;
+}
+
+/// Asserts that no matching semantics node contains another matching child node.
+void expectNoNestedSemanticsNodes(
+  SemanticsNode root, {
+  required SemanticsPredicate predicate,
+  required String debugName,
+}) {
+  final offendingNodes = <SemanticsNode>[];
+
+  bool containsMatchingDescendant(SemanticsNode node) {
+    var found = false;
+    bool visitor(SemanticsNode child) {
+      if (!child.isMergedIntoParent && predicate(child)) {
+        found = true;
+        return true;
+      }
+      child.visitChildren(visitor);
+      return true;
+    }
+
+    node.visitChildren(visitor);
+    return found;
+  }
+
+  for (final node in collectSemanticsNodes(root, predicate)) {
+    if (containsMatchingDescendant(node)) {
+      offendingNodes.add(node);
+    }
+  }
+
+  expect(
+    offendingNodes,
+    isEmpty,
+    reason: 'Expected no nested $debugName semantics nodes.',
+  );
 }
 
 /// Extracts a concise summary of a semantics node's label, value,
@@ -103,6 +195,11 @@ SemanticsSummary summarizeNode(SemanticsNode node) {
   addFlag('isTextField', data.flagsCollection.isTextField);
   addFlag('isReadOnly', data.flagsCollection.isReadOnly);
   addFlag('isMultiline', data.flagsCollection.isMultiline);
+  addFlag('scopesRoute', data.flagsCollection.scopesRoute);
+  addFlag('namesRoute', data.flagsCollection.namesRoute);
+  addFlag('isLiveRegion', data.flagsCollection.isLiveRegion);
+  addFlag('hasExpandedState', data.flagsCollection.isExpanded != Tristate.none);
+  addFlag('isExpanded', data.flagsCollection.isExpanded == Tristate.isTrue);
   addFlag(
     'isInMutuallyExclusiveGroup',
     data.flagsCollection.isInMutuallyExclusiveGroup,
@@ -124,6 +221,9 @@ SemanticsSummary summarizeNode(SemanticsNode node) {
   return SemanticsSummary(
     label: _normalizeLabel(data.label),
     value: data.value.isEmpty ? null : data.value,
+    increasedValue: data.increasedValue.isEmpty ? null : data.increasedValue,
+    decreasedValue: data.decreasedValue.isEmpty ? null : data.decreasedValue,
+    identifier: data.identifier.isEmpty ? null : data.identifier,
     flags: flags,
     actions: actions,
   );
@@ -170,6 +270,9 @@ SemanticsSummary summarizeMergedButtonFromRoot(WidgetTester tester) {
       found = SemanticsSummary(
         label: summary.label,
         value: summary.value,
+        increasedValue: summary.increasedValue,
+        decreasedValue: summary.decreasedValue,
+        identifier: summary.identifier,
         flags: mergedFlags,
         actions: mergedActions,
       );
@@ -226,6 +329,9 @@ SemanticsSummary summarizeMergedFromRoot(
       found = SemanticsSummary(
         label: summary.label,
         value: summary.value,
+        increasedValue: summary.increasedValue,
+        decreasedValue: summary.decreasedValue,
+        identifier: summary.identifier,
         flags: mergedFlags,
         actions: mergedActions,
       );
@@ -287,36 +393,6 @@ Future<void> expectSemanticsParity({
     control: control,
   );
 
-  // Certain controls (e.g., TextField) can surface focusability either on the
-  // control node or an ancestor. Allow focusable flag parity to vary while
-  // still requiring a focus action.
-  if (control == ControlType.textField) {
-    SemanticsSummary stripFocusable(SemanticsSummary s) => SemanticsSummary(
-      label: s.label,
-      value: s.value,
-      flags: s.flags.where((f) => f != 'isFocusable').toSet(),
-      actions: s.actions,
-    );
-    materialSummary = stripFocusable(materialSummary);
-    nakedSummary = stripFocusable(nakedSummary);
-  }
-
-  // Tabs (Material) may not expose button/enabled flags. Normalize them out.
-  if (control == ControlType.tab) {
-    SemanticsSummary normalizeTab(SemanticsSummary s) => SemanticsSummary(
-      label: s.label,
-      value: s.value,
-      flags: s.flags
-          .where(
-            (f) =>
-                f != 'isButton' && f != 'isEnabled' && f != 'hasEnabledState',
-          )
-          .toSet(),
-      actions: s.actions,
-    );
-    materialSummary = normalizeTab(materialSummary);
-    nakedSummary = normalizeTab(nakedSummary);
-  }
   expect(nakedSummary, equals(materialSummary));
 }
 

--- a/packages/naked_ui/test/semantics/semantics_test_utils_test.dart
+++ b/packages/naked_ui/test/semantics/semantics_test_utils_test.dart
@@ -1,0 +1,113 @@
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_test_utils.dart';
+
+void main() {
+  testWidgets('summarizeNode includes extended semantics fields', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Semantics(
+            label: 'Details',
+            value: 'Current',
+            increasedValue: 'Next',
+            decreasedValue: 'Previous',
+            expanded: true,
+            scopesRoute: true,
+            namesRoute: true,
+            explicitChildNodes: true,
+            identifier: 'details-trigger',
+            child: SizedBox(width: 10, height: 10),
+          ),
+        ),
+      ),
+    );
+
+    final node = tester.getSemantics(find.byType(SizedBox));
+    final summary = summarizeNode(node);
+
+    expect(summary.label, 'Details');
+    expect(summary.value, 'Current');
+    expect(summary.increasedValue, 'Next');
+    expect(summary.decreasedValue, 'Previous');
+    expect(summary.identifier, 'details-trigger');
+    expect(summary.flags, contains('isExpanded'));
+    expect(summary.flags, contains('scopesRoute'));
+    expect(summary.flags, contains('namesRoute'));
+    expect(node.getSemanticsData().flagsCollection.isExpanded, Tristate.isTrue);
+
+    handle.dispose();
+  });
+
+  testWidgets('summarizeNode distinguishes collapsed expanded state', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Semantics(
+            label: 'Details',
+            expanded: false,
+            child: const SizedBox(width: 10, height: 10),
+          ),
+        ),
+      ),
+    );
+
+    final summary = summarizeNode(tester.getSemantics(find.byType(SizedBox)));
+
+    expect(summary.flags, contains('hasExpandedState'));
+    expect(summary.flags, isNot(contains('isExpanded')));
+
+    handle.dispose();
+  });
+
+  testWidgets('tree helpers count matching nodes and detect nesting', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Semantics(
+            container: true,
+            textField: true,
+            child: Semantics(
+              container: true,
+              textField: true,
+              child: const SizedBox(width: 10, height: 10),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final root = tester.getSemantics(find.byType(Scaffold));
+    bool isTextField(SemanticsNode node) {
+      return node.getSemanticsData().flagsCollection.isTextField;
+    }
+
+    expect(countSemanticsNodes(root, isTextField), 2);
+    expect(
+      () => expectNoNestedSemanticsNodes(
+        root,
+        predicate: isTextField,
+        debugName: 'text field',
+      ),
+      throwsA(isA<TestFailure>()),
+    );
+
+    handle.dispose();
+  });
+}

--- a/packages/naked_ui/test/src/parity/naked_button_material_parity_test.dart
+++ b/packages/naked_ui/test/src/parity/naked_button_material_parity_test.dart
@@ -218,30 +218,20 @@ void main() {
         ),
       );
 
-      // Enabled should use click cursor
-      tester.expectCursor(SystemMouseCursors.click, on: materialEnabledKey);
-      tester.expectCursor(SystemMouseCursors.click, on: nakedEnabledKey);
-
-      // Disabled: cursors must match exactly across Material and Naked
-      final materialDisabledRegion = tester.widget<MouseRegion>(
-        find
-            .descendant(
-              of: find.byKey(materialDisabledKey),
-              matching: find.byType(MouseRegion),
-            )
-            .first,
+      await tester.expectActiveCursor(
+        SystemMouseCursors.click,
+        on: nakedEnabledKey,
       );
-      final nakedDisabledRegion = tester.widget<MouseRegion>(
-        find
-            .descendant(
-              of: find.byKey(nakedDisabledKey),
-              matching: find.byType(MouseRegion),
-            )
-            .first,
+
+      final materialDisabledCursor = await tester.activeCursorFor(
+        materialDisabledKey,
+      );
+      final nakedDisabledCursor = await tester.activeCursorFor(
+        nakedDisabledKey,
       );
       expect(
-        materialDisabledRegion.cursor,
-        equals(nakedDisabledRegion.cursor),
+        nakedDisabledCursor,
+        equals(materialDisabledCursor),
         reason: 'Disabled cursor must be identical for parity',
       );
     });

--- a/packages/naked_ui/test/src/parity/naked_checkbox_material_parity_test.dart
+++ b/packages/naked_ui/test/src/parity/naked_checkbox_material_parity_test.dart
@@ -210,24 +210,24 @@ void main() {
         ),
       );
 
-      tester.expectCursor(SystemMouseCursors.click, on: materialEnabledKey);
-      tester.expectCursor(SystemMouseCursors.click, on: nakedEnabledKey);
+      await tester.expectActiveCursor(
+        SystemMouseCursors.click,
+        on: nakedEnabledKey,
+      );
 
-      final materialDisabledRegion = tester.widget<MouseRegion>(
-        find
-            .descendant(
-              of: find.byKey(materialDisabledKey),
-              matching: find.byType(MouseRegion),
-            )
-            .first,
+      final materialDisabledCursor = await tester.activeCursorFor(
+        materialDisabledKey,
       );
       expect(
-        materialDisabledRegion.cursor == SystemMouseCursors.basic ||
-            materialDisabledRegion.cursor == MouseCursor.defer,
+        materialDisabledCursor == SystemMouseCursors.basic ||
+            materialDisabledCursor == MouseCursor.defer,
         isTrue,
         reason: 'Material disabled cursor should be basic or defer',
       );
-      tester.expectCursor(SystemMouseCursors.basic, on: nakedDisabledKey);
+      await tester.expectActiveCursor(
+        SystemMouseCursors.basic,
+        on: nakedDisabledKey,
+      );
     });
 
     testWidgets(

--- a/packages/naked_ui/test/src/parity/naked_radio_material_parity_test.dart
+++ b/packages/naked_ui/test/src/parity/naked_radio_material_parity_test.dart
@@ -331,24 +331,22 @@ void main() {
         ),
       );
 
-      tester.expectCursor(SystemMouseCursors.click, on: mEnabledKey);
-      tester.expectCursor(SystemMouseCursors.click, on: nEnabledKey);
-
-      final materialDisabledRegion = tester.widget<MouseRegion>(
-        find
-            .descendant(
-              of: find.byKey(mDisabledKey),
-              matching: find.byType(MouseRegion),
-            )
-            .first,
+      await tester.expectActiveCursor(
+        SystemMouseCursors.click,
+        on: nEnabledKey,
       );
+
+      final materialDisabledCursor = await tester.activeCursorFor(mDisabledKey);
       expect(
-        materialDisabledRegion.cursor == SystemMouseCursors.basic ||
-            materialDisabledRegion.cursor == MouseCursor.defer,
+        materialDisabledCursor == SystemMouseCursors.basic ||
+            materialDisabledCursor == MouseCursor.defer,
         isTrue,
         reason: 'Material disabled cursor should be basic or defer',
       );
-      tester.expectCursor(SystemMouseCursors.basic, on: nDisabledKey);
+      await tester.expectActiveCursor(
+        SystemMouseCursors.basic,
+        on: nDisabledKey,
+      );
     });
   });
 }

--- a/packages/naked_ui/test/test_helpers.dart
+++ b/packages/naked_ui/test/test_helpers.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -63,6 +64,29 @@ extension WidgetTesterExtension on WidgetTester {
     );
 
     expect(region.cursor, cursor);
+  }
+
+  Future<MouseCursor?> activeCursorFor(Key key) async {
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+
+    final gesture = await createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+
+    try {
+      await pump();
+      await gesture.moveTo(getCenter(find.byKey(key)));
+      await pumpAndSettle();
+
+      return RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1);
+    } finally {
+      await gesture.removePointer();
+      await pump();
+    }
+  }
+
+  Future<void> expectActiveCursor(MouseCursor cursor, {required Key on}) async {
+    expect(await activeCursorFor(on), cursor);
   }
 
   /// Helper to verify widget interaction states for Set<WidgetState> snapshots.


### PR DESCRIPTION
## Summary
- correct semantic labels and expanded state for menu, select, accordion, and radio controls
- remove exposed nested control/text-field semantics in select and text field paths
- add slider semantic value formatting and strengthen semantics tree helpers/tests
- add an example Semantics Playground for default visible labels vs explicit semantic overrides

## Verification
- dart format --output=none --set-exit-if-changed .
- git diff --check
- flutter analyze --no-pub --fatal-infos
- flutter test --no-pub test/semantics
- flutter test --no-pub test/src/naked_select_test.dart test/src/naked_menu_test.dart test/src/naked_textfield_test.dart test/src/naked_slider_test.dart test/src/naked_accordion_test.dart test/exclude_semantics_test.dart
- flutter test --no-pub ../../.context/semantics_tree_audit_test.dart --reporter expanded
- cd packages/example && dart format --output=none --set-exit-if-changed lib test
- cd packages/example && flutter analyze --no-pub --fatal-infos
- cd packages/example && flutter test --no-pub
- cd packages/example && flutter build web --no-pub
- Playwright browser check against built web output: .context/semantics_playground.spec.cjs passed

## Known Existing Failure
- flutter test --no-pub still fails only the existing cursor parity expectations for button, checkbox, and radio hover cursors: expected click, actual basic.

## Note
- The example web scaffold remains ignored by repo policy for example native folders; local browser verification used regenerated web files from flutter create . --platforms web --no-pub.