### PR TITLE
refactor(naked-tooltip): replace RawMenuAnchor with RawTooltip

### DIFF
--- a/docs/widget/tooltip.mdx
+++ b/docs/widget/tooltip.mdx
@@ -43,7 +43,7 @@ class TooltipExample extends StatelessWidget {
         ),
         child: const Icon(Icons.copy, color: Colors.white, size: 18),
       ),
-      tooltipBuilder: (context, animation) {
+      overlayBuilder: (context, animation) {
         return FadeTransition(
           opacity: animation,
           child: Material(
@@ -56,7 +56,7 @@ class TooltipExample extends StatelessWidget {
           ),
         );
       },
-      semanticsLabel: 'Copy button tooltip',
+      semanticLabel: 'Copy button tooltip',
     );
   }
 }
@@ -68,7 +68,7 @@ class TooltipExample extends StatelessWidget {
 const NakedTooltip({
   Key? key,
   required this.child,
-  required this.tooltipBuilder,
+  required this.overlayBuilder,
   this.hoverDelay = Duration.zero,
   this.touchDelay = const Duration(milliseconds: 1500),
   this.dismissDelay = const Duration(milliseconds: 100),
@@ -77,9 +77,8 @@ const NakedTooltip({
   this.enableFeedback = true,
   this.onTriggered,
   this.animationStyle,
-  this.positioning,
-  this.positionDelegate,
-  this.semanticsLabel,
+  this.positioning = const OverlayPositionConfig(),
+  this.semanticLabel,
   this.excludeSemantics = false,
 })
 ```
@@ -87,23 +86,22 @@ const NakedTooltip({
 ### Key Parameters
 
 - `child` → trigger widget that displays the tooltip on hover/touch
-- `tooltipBuilder` → `(BuildContext, Animation<double>)` that returns the tooltip body; the animation drives show/hide transitions
+- `overlayBuilder` → `(BuildContext, Animation<double>)` that returns the tooltip body; the animation drives show/hide transitions
 - `hoverDelay` → delay before showing once hover occurs (default: immediate)
 - `dismissDelay` → delay before hiding after mouse exits (default: 100ms)
 - `touchDelay` → how long the tooltip stays visible after touch release (default: 1500ms)
 - `positioning` → `OverlayPositionConfig` controlling anchor & offset
-- `positionDelegate` → alternative `TooltipPositionDelegate` for custom positioning
 - `triggerMode` → how touch events trigger the tooltip (longPress, tap, or manual)
 - `animationStyle` → customize animation duration, curve, and reverse behavior
 - `onTriggered` → called when triggered by tap or long press (not hover)
-- `semanticsLabel` → text announced by assistive technologies
+- `semanticLabel` → text announced by assistive technologies
 - `excludeSemantics` → hide tooltip semantics from accessibility services
 
 ## Behaviour Notes
 
 - Tooltips open on pointer hover automatically
 - Touch triggers depend on `triggerMode` (longPress by default, or tap)
-- The `tooltipBuilder` receives an `Animation<double>` (0→1 on show, 1→0 on hide) for smooth transitions
+- The `overlayBuilder` receives an `Animation<double>` (0→1 on show, 1→0 on hide) for smooth transitions
 - Use `AnimationStyle.noAnimation` to disable the built-in transition
 - The tooltip dismisses on outside tap (controllable via `enableTapToDismiss`)
 - Only one tooltip is shown at a time when using nested tooltips
@@ -120,16 +118,4 @@ const OverlayPositionConfig(
 );
 ```
 
-For advanced positioning, use `positionDelegate` which receives a `TooltipPositionContext` with target location, sizes, and overlay bounds:
-
-```dart
-NakedTooltip(
-  positionDelegate: (context) {
-    return Offset(
-      context.target.dx + context.targetSize.width / 2,
-      context.target.dy - context.tooltipSize.height / 2,
-    );
-  },
-  // ...
-)
-```
+For fully custom positioning beyond what `OverlayPositionConfig` exposes, drop down to Flutter's `RawTooltip` directly and supply your own `TooltipPositionDelegate`.

--- a/docs/widget/tooltip.mdx
+++ b/docs/widget/tooltip.mdx
@@ -1,10 +1,10 @@
 ---
 title: NakedTooltip
-description: Hover/focus triggered tooltip overlay with positioning and lifecycle callbacks
+description: Hover/touch triggered tooltip overlay with positioning, animation, and lifecycle callbacks
 keywords: [flutter, tooltip, hover, overlay, headless]
 ---
 
-Headless tooltip component. Handles hover/focus triggers, positioning, timers, and dismissal. Use builder pattern for custom styling.
+Headless tooltip component built on Flutter's `RawTooltip`. Handles hover/touch triggers, positioning, animations, timers, and dismissal. The builder receives an `Animation` for easy transitions.
 
 ## When to use this
 
@@ -23,25 +23,8 @@ Headless tooltip component. Handles hover/focus triggers, positioning, timers, a
 import 'package:flutter/material.dart';
 import 'package:naked_ui/naked_ui.dart';
 
-class TooltipExample extends StatefulWidget {
+class TooltipExample extends StatelessWidget {
   const TooltipExample({super.key});
-
-  @override
-  State<TooltipExample> createState() => _TooltipExampleState();
-}
-
-class _TooltipExampleState extends State<TooltipExample>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _controller = AnimationController(
-    duration: const Duration(milliseconds: 200),
-    vsync: this,
-  );
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -50,10 +33,8 @@ class _TooltipExampleState extends State<TooltipExample>
         targetAnchor: Alignment.topCenter,
         followerAnchor: Alignment.bottomCenter,
       ),
-      waitDuration: const Duration(milliseconds: 400),
-      showDuration: const Duration(seconds: 2),
-      onOpen: () => _controller.forward(),
-      onClose: () => _controller.reverse(),
+      hoverDelay: const Duration(milliseconds: 400),
+      dismissDelay: const Duration(seconds: 2),
       child: Container(
         padding: const EdgeInsets.all(10),
         decoration: BoxDecoration(
@@ -62,9 +43,9 @@ class _TooltipExampleState extends State<TooltipExample>
         ),
         child: const Icon(Icons.copy, color: Colors.white, size: 18),
       ),
-      overlayBuilder: (context, info) {
+      tooltipBuilder: (context, animation) {
         return FadeTransition(
-          opacity: _controller,
+          opacity: animation,
           child: Material(
             elevation: 4,
             borderRadius: BorderRadius.circular(8),
@@ -87,38 +68,45 @@ class _TooltipExampleState extends State<TooltipExample>
 const NakedTooltip({
   Key? key,
   required this.child,
-  required this.overlayBuilder,
-  this.showDuration = const Duration(seconds: 2),
-  this.waitDuration = const Duration(seconds: 1),
-  this.positioning = const OverlayPositionConfig(
-    targetAnchor: Alignment.topCenter,
-    followerAnchor: Alignment.bottomCenter,
-  ),
-  this.onOpen,
-  this.onClose,
-  this.onOpenRequested,
-  this.onCloseRequested,
+  required this.tooltipBuilder,
+  this.hoverDelay = Duration.zero,
+  this.touchDelay = const Duration(milliseconds: 1500),
+  this.dismissDelay = const Duration(milliseconds: 100),
+  this.enableTapToDismiss = true,
+  this.triggerMode = TooltipTriggerMode.longPress,
+  this.enableFeedback = true,
+  this.onTriggered,
+  this.animationStyle,
+  this.positioning,
+  this.positionDelegate,
   this.semanticsLabel,
+  this.excludeSemantics = false,
 })
 ```
 
 ### Key Parameters
 
-- `child` → trigger widget that displays the tooltip on hover/focus
-- `overlayBuilder` → `(BuildContext, RawMenuAnchorOverlayInfo)` that returns the tooltip body each time it shows
-- `showDuration` → how long the tooltip stays visible before hiding automatically
-- `waitDuration` → delay before showing once hover/focus occurs
+- `child` → trigger widget that displays the tooltip on hover/touch
+- `tooltipBuilder` → `(BuildContext, Animation<double>)` that returns the tooltip body; the animation drives show/hide transitions
+- `hoverDelay` → delay before showing once hover occurs (default: immediate)
+- `dismissDelay` → delay before hiding after mouse exits (default: 100ms)
+- `touchDelay` → how long the tooltip stays visible after touch release (default: 1500ms)
 - `positioning` → `OverlayPositionConfig` controlling anchor & offset
-- `onOpen` / `onClose` → lifecycle hooks useful for animations
-- `onOpenRequested` / `onCloseRequested` → intercept show/hide requests (e.g. async delays)
-- `semanticsLabel` → text announced by assistive technologies on hover/focus
+- `positionDelegate` → alternative `TooltipPositionDelegate` for custom positioning
+- `triggerMode` → how touch events trigger the tooltip (longPress, tap, or manual)
+- `animationStyle` → customize animation duration, curve, and reverse behavior
+- `onTriggered` → called when triggered by tap or long press (not hover)
+- `semanticsLabel` → text announced by assistive technologies
+- `excludeSemantics` → hide tooltip semantics from accessibility services
 
 ## Behaviour Notes
 
-- Tooltips open on pointer hover and keyboard focus
-- When `waitDuration` elapses, the overlay opens via `RawMenuAnchor`; timers reset on exit
-- The overlay hides after `showDuration`; supply `onClose` for exit animations
-- The trigger remains focusable; use `semanticsLabel` for descriptive text when the trigger has no visible label
+- Tooltips open on pointer hover automatically
+- Touch triggers depend on `triggerMode` (longPress by default, or tap)
+- The `tooltipBuilder` receives an `Animation<double>` (0→1 on show, 1→0 on hide) for smooth transitions
+- Use `AnimationStyle.noAnimation` to disable the built-in transition
+- The tooltip dismisses on outside tap (controllable via `enableTapToDismiss`)
+- Only one tooltip is shown at a time when using nested tooltips
 
 ## Positioning Tips
 
@@ -132,4 +120,16 @@ const OverlayPositionConfig(
 );
 ```
 
-The overlay builder receives `RawMenuAnchorOverlayInfo` (`info` in the sample) with `anchorRect`, `overlaySize`, and `position` should you need pointer coordinates for arrow placement.
+For advanced positioning, use `positionDelegate` which receives a `TooltipPositionContext` with target location, sizes, and overlay bounds:
+
+```dart
+NakedTooltip(
+  positionDelegate: (context) {
+    return Offset(
+      context.target.dx + context.targetSize.width / 2,
+      context.target.dy - context.tooltipSize.height / 2,
+    );
+  },
+  // ...
+)
+```

--- a/packages/example/integration_test/components/naked_tooltip_integration.dart
+++ b/packages/example/integration_test/components/naked_tooltip_integration.dart
@@ -10,53 +10,40 @@ void main() {
 
   group('NakedTooltip Integration Tests', () {
     testWidgets('tooltip shows on hover and hides on exit', (tester) async {
-      // Use the actual example app
       await tester.pumpWidget(const tooltip_example.MyApp());
       await tester.pump(const Duration(milliseconds: 100));
 
       final tooltipFinder = find.byType(NakedTooltip);
       expect(tooltipFinder, findsOneWidget);
 
-      // Use the tooltip widget itself as the hover target for reliability
       final triggerFinder = tooltipFinder;
 
-      // Initially tooltip content should not be visible
       expect(find.text('This is a tooltip'), findsNothing);
 
-      // Simulate hover enter (add and move pointer to trigger center)
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
       addTearDown(gesture.removePointer);
       await gesture.moveTo(tester.getCenter(triggerFinder));
-      await tester.pumpAndSettle(); // Wait for waitDuration and animations
+      await tester.pumpAndSettle();
 
-      // Tooltip should be visible now
       expect(find.text('This is a tooltip'), findsOneWidget);
 
-      // Simulate hover exit
       await gesture.moveTo(const Offset(0, 0));
-      await tester.pump(
-        const Duration(milliseconds: 350),
-      ); // Wait for animation + removal
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
 
-      // Tooltip should be hidden now
       expect(find.text('This is a tooltip'), findsNothing);
     }, skip: true);
 
-    testWidgets('tooltip respects wait duration', (tester) async {
-      bool tooltipOpened = false;
-
+    testWidgets('tooltip respects hover delay', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: Center(
               child: NakedTooltip(
-                waitDuration: const Duration(milliseconds: 500),
-                showDuration: Duration.zero,
-                onOpen: () {
-                  tooltipOpened = true;
-                },
-                overlayBuilder: (context, info) => Container(
+                hoverDelay: const Duration(milliseconds: 500),
+                dismissDelay: Duration.zero,
+                tooltipBuilder: (context, animation) => Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     color: Colors.black,
@@ -87,41 +74,30 @@ void main() {
       final triggerFinder = find.text('Hover me');
       expect(triggerFinder, findsOneWidget);
 
-      // Initially tooltip should not be visible
       expect(find.text('Tooltip'), findsNothing);
-      expect(tooltipOpened, false);
 
-      // Start hovering
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
       addTearDown(gesture.removePointer);
       await gesture.moveTo(tester.getCenter(triggerFinder));
 
-      // Should not be visible immediately (wait duration not elapsed)
       await tester.pump(const Duration(milliseconds: 100));
       expect(find.text('Tooltip'), findsNothing);
-      expect(tooltipOpened, false);
 
-      // Should be visible after wait duration
       await tester.pump(const Duration(milliseconds: 450));
+      await tester.pumpAndSettle();
       expect(find.text('Tooltip'), findsOneWidget);
-      expect(tooltipOpened, true);
     });
 
     testWidgets('tooltip shows on hover with zero durations', (tester) async {
-      bool tooltipOpened = false;
-      bool tooltipClosed = false;
-
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: Center(
               child: NakedTooltip(
-                waitDuration: Duration.zero,
-                showDuration: Duration.zero,
-                onOpen: () => tooltipOpened = true,
-                onClose: () => tooltipClosed = true,
-                overlayBuilder: (context, info) => Container(
+                hoverDelay: Duration.zero,
+                dismissDelay: Duration.zero,
+                tooltipBuilder: (context, animation) => Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     color: Colors.black,
@@ -152,12 +128,8 @@ void main() {
       final triggerFinder = find.text('Hover me');
       expect(triggerFinder, findsOneWidget);
 
-      // Initially tooltip should not be visible
       expect(find.text('Tooltip'), findsNothing);
-      expect(tooltipOpened, false);
-      expect(tooltipClosed, false);
 
-      // Hover to show
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
       addTearDown(gesture.removePointer);
@@ -165,14 +137,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Tooltip'), findsOneWidget);
-      expect(tooltipOpened, true);
-      expect(tooltipClosed, false);
 
-      // Move out to hide
       await gesture.moveTo(const Offset(0, 0));
       await tester.pumpAndSettle();
       expect(find.text('Tooltip'), findsNothing);
-      expect(tooltipClosed, true);
     });
 
     testWidgets('tooltip positioning works correctly', (tester) async {
@@ -185,9 +153,9 @@ void main() {
                   targetAnchor: Alignment.bottomCenter,
                   followerAnchor: Alignment.topCenter,
                 ),
-                waitDuration: Duration.zero,
-                showDuration: Duration.zero,
-                overlayBuilder: (context, info) => Container(
+                hoverDelay: Duration.zero,
+                dismissDelay: Duration.zero,
+                tooltipBuilder: (context, animation) => Container(
                   width: 100,
                   height: 50,
                   padding: const EdgeInsets.all(8),
@@ -219,24 +187,19 @@ void main() {
         ),
       );
 
-      // Use the tooltip widget itself as the hover target for reliability
       final triggerFinder = find.byType(NakedTooltip);
       expect(triggerFinder, findsOneWidget);
 
-      // Initially tooltip should not be visible
       expect(find.text('Positioned Tooltip'), findsNothing);
 
-      // Hover to show tooltip
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
       addTearDown(gesture.removePointer);
       await gesture.moveTo(tester.getCenter(triggerFinder));
       await tester.pumpAndSettle();
 
-      // Tooltip should be visible and positioned correctly
       expect(find.text('Positioned Tooltip'), findsOneWidget);
 
-      // Check that tooltip rect is valid and on screen
       final tooltipRect = tester.getRect(find.text('Positioned Tooltip'));
 
       expect(tooltipRect.size.height, greaterThan(0));

--- a/packages/example/integration_test/components/naked_tooltip_integration.dart
+++ b/packages/example/integration_test/components/naked_tooltip_integration.dart
@@ -43,7 +43,7 @@ void main() {
               child: NakedTooltip(
                 hoverDelay: const Duration(milliseconds: 500),
                 dismissDelay: Duration.zero,
-                tooltipBuilder: (context, animation) => Container(
+                overlayBuilder: (context, animation) => Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     color: Colors.black,
@@ -97,7 +97,7 @@ void main() {
               child: NakedTooltip(
                 hoverDelay: Duration.zero,
                 dismissDelay: Duration.zero,
-                tooltipBuilder: (context, animation) => Container(
+                overlayBuilder: (context, animation) => Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     color: Colors.black,
@@ -155,7 +155,7 @@ void main() {
                 ),
                 hoverDelay: Duration.zero,
                 dismissDelay: Duration.zero,
-                tooltipBuilder: (context, animation) => Container(
+                overlayBuilder: (context, animation) => Container(
                   width: 100,
                   height: 50,
                   padding: const EdgeInsets.all(8),

--- a/packages/example/lib/api/naked_tooltip.0.dart
+++ b/packages/example/lib/api/naked_tooltip.0.dart
@@ -36,48 +36,22 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class TooltipExample extends StatefulWidget {
+class TooltipExample extends StatelessWidget {
   const TooltipExample({super.key});
-
-  @override
-  State<TooltipExample> createState() => _TooltipExampleState();
-}
-
-class _TooltipExampleState extends State<TooltipExample>
-    with SingleTickerProviderStateMixin {
-  late final _animationController = AnimationController(
-    duration: const Duration(milliseconds: 300),
-    vsync: this,
-  );
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return NakedTooltip(
       semanticsLabel: 'This is a tooltip',
       positioning: const OverlayPositionConfig(
-        targetAnchor: Alignment.bottomCenter,
+        targetAnchor: Alignment.bottomRight,
         followerAnchor: Alignment.topCenter,
         offset: Offset(0, 4),
       ),
-      waitDuration: const Duration(seconds: 0),
-      showDuration: const Duration(seconds: 1),
-      onOpenRequested: (_, show) {
-        show();
-        _animationController.forward();
-      },
-      onCloseRequested: (hide) {
-        _animationController.reverse().then((value) {
-          hide();
-        });
-      },
-      overlayBuilder: (context, info) => FadeTransition(
-        opacity: _animationController,
+      hoverDelay: Duration.zero,
+      dismissDelay: const Duration(seconds: 1),
+      tooltipBuilder: (context, animation) => FadeTransition(
+        opacity: animation,
         child: Container(
           decoration: BoxDecoration(
             color: Colors.black54,

--- a/packages/example/lib/api/naked_tooltip.0.dart
+++ b/packages/example/lib/api/naked_tooltip.0.dart
@@ -42,7 +42,7 @@ class TooltipExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return NakedTooltip(
-      semanticsLabel: 'This is a tooltip',
+      semanticLabel: 'This is a tooltip',
       positioning: const OverlayPositionConfig(
         targetAnchor: Alignment.bottomRight,
         followerAnchor: Alignment.topCenter,
@@ -50,7 +50,7 @@ class TooltipExample extends StatelessWidget {
       ),
       hoverDelay: Duration.zero,
       dismissDelay: const Duration(seconds: 1),
-      tooltipBuilder: (context, animation) => FadeTransition(
+      overlayBuilder: (context, animation) => FadeTransition(
         opacity: animation,
         child: Container(
           decoration: BoxDecoration(

--- a/packages/naked_ui/lib/src/naked_tooltip.dart
+++ b/packages/naked_ui/lib/src/naked_tooltip.dart
@@ -9,7 +9,7 @@ import 'utilities/positioning.dart';
 /// dismissal. Wraps Flutter's [RawTooltip] to provide a consistent
 /// naked_ui API with support for [OverlayPositionConfig]-based positioning.
 ///
-/// The [tooltipBuilder] receives an [Animation] that drives the tooltip's
+/// The [overlayBuilder] receives an [Animation] that drives the tooltip's
 /// show/hide transition, making it easy to add fade, scale, or custom
 /// animations.
 ///
@@ -21,7 +21,7 @@ import 'utilities/positioning.dart';
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return NakedTooltip(
-///       semanticsLabel: 'This is a tooltip',
+///       semanticLabel: 'This is a tooltip',
 ///       positioning: const OverlayPositionConfig(
 ///         targetAnchor: Alignment.bottomCenter,
 ///         followerAnchor: Alignment.topCenter,
@@ -29,7 +29,7 @@ import 'utilities/positioning.dart';
 ///       ),
 ///       hoverDelay: Duration.zero,
 ///       dismissDelay: const Duration(seconds: 1),
-///       tooltipBuilder: (context, animation) => FadeTransition(
+///       overlayBuilder: (context, animation) => FadeTransition(
 ///         opacity: animation,
 ///         child: Container(
 ///           decoration: BoxDecoration(
@@ -63,7 +63,7 @@ class NakedTooltip extends StatefulWidget {
   const NakedTooltip({
     super.key,
     required this.child,
-    required this.tooltipBuilder,
+    required this.overlayBuilder,
     this.hoverDelay = Duration.zero,
     this.touchDelay = const Duration(milliseconds: 1500),
     this.dismissDelay = const Duration(milliseconds: 100),
@@ -76,14 +76,10 @@ class NakedTooltip extends StatefulWidget {
       duration: Duration(milliseconds: 150),
       reverseDuration: Duration(milliseconds: 75),
     ),
-    this.positioning,
-    this.positionDelegate,
-    this.semanticsLabel,
+    this.positioning = const OverlayPositionConfig(),
+    this.semanticLabel,
     this.excludeSemantics = false,
-  }) : assert(
-         positioning == null || positionDelegate == null,
-         'Cannot provide both positioning and positionDelegate',
-       );
+  });
 
   /// See also:
   /// - [NakedPopover], for anchored, click-triggered overlays.
@@ -96,24 +92,16 @@ class NakedTooltip extends StatefulWidget {
   /// The [animation] drives the show/hide transition (0.0 → 1.0 when showing,
   /// 1.0 → 0.0 when hiding). Use it with [FadeTransition], [ScaleTransition],
   /// or similar widgets for animated tooltips.
-  final TooltipComponentBuilder tooltipBuilder;
+  final TooltipComponentBuilder overlayBuilder;
 
   /// The semantic label for screen readers.
   ///
   /// When null, the trigger keeps its own accessible name, but no tooltip
   /// semantic text is exposed.
-  final String? semanticsLabel;
+  final String? semanticLabel;
 
   /// Positioning configuration for the overlay using anchor-based alignment.
-  ///
-  /// Cannot be used together with [positionDelegate].
-  final OverlayPositionConfig? positioning;
-
-  /// A custom position delegate for computing where the tooltip should
-  /// be positioned relative to the target.
-  ///
-  /// Cannot be used together with [positioning].
-  final TooltipPositionDelegate? positionDelegate;
+  final OverlayPositionConfig positioning;
 
   /// The delay before the tooltip is shown when hovering with a mouse.
   ///
@@ -170,34 +158,26 @@ class NakedTooltip extends StatefulWidget {
 }
 
 class _NakedTooltipState extends State<NakedTooltip> {
-  TooltipPositionDelegate? _cachedPositionDelegate;
+  late TooltipPositionDelegate _positionDelegate;
 
   @override
   void initState() {
     super.initState();
-    _updatePositionDelegate();
+    _positionDelegate = _buildPositionDelegate(widget.positioning);
   }
 
   @override
   void didUpdateWidget(NakedTooltip oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.positioning != oldWidget.positioning ||
-        widget.positionDelegate != oldWidget.positionDelegate) {
-      _updatePositionDelegate();
+    if (widget.positioning != oldWidget.positioning) {
+      _positionDelegate = _buildPositionDelegate(widget.positioning);
     }
   }
 
-  void _updatePositionDelegate() {
-    if (widget.positionDelegate != null) {
-      _cachedPositionDelegate = widget.positionDelegate;
-      return;
-    }
-    if (widget.positioning == null) {
-      _cachedPositionDelegate = null;
-      return;
-    }
-    final config = widget.positioning!;
-    _cachedPositionDelegate = (TooltipPositionContext context) {
+  static TooltipPositionDelegate _buildPositionDelegate(
+    OverlayPositionConfig config,
+  ) {
+    return (TooltipPositionContext context) {
       final targetTopLeft =
           context.target - context.targetSize.center(Offset.zero);
       final targetAnchorOffset = config.targetAnchor.alongSize(
@@ -234,8 +214,8 @@ class _NakedTooltipState extends State<NakedTooltip> {
   @override
   Widget build(BuildContext context) {
     return RawTooltip(
-      semanticsTooltip: widget.excludeSemantics ? null : widget.semanticsLabel,
-      tooltipBuilder: widget.tooltipBuilder,
+      semanticsTooltip: widget.excludeSemantics ? null : widget.semanticLabel,
+      tooltipBuilder: widget.overlayBuilder,
       hoverDelay: widget.hoverDelay,
       touchDelay: widget.touchDelay,
       dismissDelay: widget.dismissDelay,
@@ -244,7 +224,7 @@ class _NakedTooltipState extends State<NakedTooltip> {
       enableFeedback: widget.enableFeedback,
       onTriggered: widget.onTriggered,
       animationStyle: widget.animationStyle,
-      positionDelegate: _cachedPositionDelegate,
+      positionDelegate: _positionDelegate,
       child: widget.child,
     );
   }

--- a/packages/naked_ui/lib/src/naked_tooltip.dart
+++ b/packages/naked_ui/lib/src/naked_tooltip.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-
-import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
 import 'naked_widgets.dart';
@@ -9,29 +6,17 @@ import 'utilities/positioning.dart';
 /// Provides tooltip behavior without visual styling.
 ///
 /// Handles showing, hiding, and positioning tooltips with automatic
-/// dismissal after specified duration.
+/// dismissal. Wraps Flutter's [RawTooltip] to provide a consistent
+/// naked_ui API with support for [OverlayPositionConfig]-based positioning.
+///
+/// The [tooltipBuilder] receives an [Animation] that drives the tooltip's
+/// show/hide transition, making it easy to add fade, scale, or custom
+/// animations.
 ///
 /// Example:
 /// ```dart
-/// class TooltipExample extends StatefulWidget {
-///  const TooltipExample({super.key});
-///
-///   @override
-///   State<TooltipExample> createState() => _TooltipExampleState();
-/// }
-///
-/// class _TooltipExampleState extends State<TooltipExample>
-///     with SingleTickerProviderStateMixin {
-///   late final _animationController = AnimationController(
-///     duration: const Duration(milliseconds: 300),
-///     vsync: this,
-///   );
-///
-///   @override
-///   void dispose() {
-///     _animationController.dispose();
-///     super.dispose();
-///   }
+/// class TooltipExample extends StatelessWidget {
+///   const TooltipExample({super.key});
 ///
 ///   @override
 ///   Widget build(BuildContext context) {
@@ -42,19 +27,10 @@ import 'utilities/positioning.dart';
 ///         followerAnchor: Alignment.topCenter,
 ///         offset: Offset(0, 4),
 ///       ),
-///       waitDuration: const Duration(seconds: 0),
-///       showDuration: const Duration(seconds: 1),
-///       onOpenRequested: (_, show) {
-///         show();
-///         _animationController.forward();
-///       },
-///       onCloseRequested: (hide) {
-///         _animationController.reverse().then((value) {
-///           hide();
-///         });
-///       },
-///       overlayBuilder: (context, info) => FadeTransition(
-///         opacity: _animationController,
+///       hoverDelay: Duration.zero,
+///       dismissDelay: const Duration(seconds: 1),
+///       tooltipBuilder: (context, animation) => FadeTransition(
+///         opacity: animation,
 ///         child: Container(
 ///           decoration: BoxDecoration(
 ///             color: Colors.black54,
@@ -87,20 +63,27 @@ class NakedTooltip extends StatefulWidget {
   const NakedTooltip({
     super.key,
     required this.child,
-    required this.overlayBuilder,
-    this.showDuration = const Duration(seconds: 2),
-    this.waitDuration = const Duration(seconds: 1),
-    this.positioning = const OverlayPositionConfig(
-      targetAnchor: Alignment.topCenter,
-      followerAnchor: Alignment.bottomCenter,
+    required this.tooltipBuilder,
+    this.hoverDelay = Duration.zero,
+    this.touchDelay = const Duration(milliseconds: 1500),
+    this.dismissDelay = const Duration(milliseconds: 100),
+    this.enableTapToDismiss = true,
+    this.triggerMode = TooltipTriggerMode.longPress,
+    this.enableFeedback = true,
+    this.onTriggered,
+    this.animationStyle = const AnimationStyle(
+      curve: Curves.fastOutSlowIn,
+      duration: Duration(milliseconds: 150),
+      reverseDuration: Duration(milliseconds: 75),
     ),
-    this.onOpen,
-    this.onClose,
-    this.onOpenRequested,
-    this.onCloseRequested,
+    this.positioning,
+    this.positionDelegate,
     this.semanticsLabel,
     this.excludeSemantics = false,
-  });
+  }) : assert(
+         positioning == null || positionDelegate == null,
+         'Cannot provide both positioning and positionDelegate',
+       );
 
   /// See also:
   /// - [NakedPopover], for anchored, click-triggered overlays.
@@ -108,8 +91,12 @@ class NakedTooltip extends StatefulWidget {
   /// The widget that triggers the tooltip.
   final Widget child;
 
-  /// The tooltip content overlayBuilder.
-  final RawMenuAnchorOverlayBuilder overlayBuilder;
+  /// Builds the tooltip content displayed in the overlay.
+  ///
+  /// The [animation] drives the show/hide transition (0.0 → 1.0 when showing,
+  /// 1.0 → 0.0 when hiding). Use it with [FadeTransition], [ScaleTransition],
+  /// or similar widgets for animated tooltips.
+  final TooltipComponentBuilder tooltipBuilder;
 
   /// The semantic label for screen readers.
   ///
@@ -117,36 +104,65 @@ class NakedTooltip extends StatefulWidget {
   /// semantic text is exposed.
   final String? semanticsLabel;
 
-  /// Positioning configuration for the overlay.
-  final OverlayPositionConfig positioning;
-
-  /// The duration tooltip remains visible.
-  final Duration showDuration;
-
-  /// The duration to wait before showing tooltip.
-  final Duration waitDuration;
-
-  /// Called when the tooltip opens.
-  final VoidCallback? onOpen;
-
-  /// Called when the tooltip closes.
-  final VoidCallback? onClose;
-
-  /// Called when a request is made to open the tooltip.
+  /// Positioning configuration for the overlay using anchor-based alignment.
   ///
-  /// Allows customizing opening behavior with animations or delays.
-  /// Call the provided callback to show the tooltip.
-  final RawMenuAnchorOpenRequestedCallback? onOpenRequested;
+  /// Cannot be used together with [positionDelegate].
+  final OverlayPositionConfig? positioning;
 
-  /// Called when a request is made to close the tooltip.
+  /// A custom position delegate for computing where the tooltip should
+  /// be positioned relative to the target.
   ///
-  /// Allows customizing closing behavior with animations or delays.
-  /// Call the provided callback to hide the tooltip.
-  final RawMenuAnchorCloseRequestedCallback? onCloseRequested;
+  /// Cannot be used together with [positioning].
+  final TooltipPositionDelegate? positionDelegate;
+
+  /// The delay before the tooltip is shown when hovering with a mouse.
+  ///
+  /// Defaults to [Duration.zero] (shown immediately on hover).
+  final Duration hoverDelay;
+
+  /// The duration the tooltip remains visible after a touch trigger is released.
+  ///
+  /// Does not affect mouse pointer devices.
+  ///
+  /// Defaults to 1500 milliseconds.
+  final Duration touchDelay;
+
+  /// The delay before the tooltip is hidden after the mouse exits.
+  ///
+  /// Defaults to 100 milliseconds.
+  final Duration dismissDelay;
+
+  /// Whether the tooltip can be dismissed by tapping elsewhere.
+  ///
+  /// Defaults to true.
+  final bool enableTapToDismiss;
+
+  /// How touch events should trigger the tooltip.
+  ///
+  /// Does not affect mouse hover behavior.
+  ///
+  /// Defaults to [TooltipTriggerMode.longPress].
+  final TooltipTriggerMode triggerMode;
+
+  /// Whether haptic/acoustic feedback is provided on touch trigger.
+  ///
+  /// Defaults to true.
+  final bool enableFeedback;
+
+  /// Called when the tooltip is triggered by tap or long press.
+  ///
+  /// Not called for mouse hover triggers.
+  final TooltipTriggeredCallback? onTriggered;
+
+  /// The animation style for the tooltip show/hide transition.
+  ///
+  /// Use [AnimationStyle.noAnimation] to disable animation.
+  final AnimationStyle animationStyle;
 
   /// Whether to exclude this widget from the semantic tree.
   ///
-  /// When true, the widget and its children are hidden from accessibility services.
+  /// When true, no tooltip semantics text is exposed to
+  /// accessibility services.
   final bool excludeSemantics;
 
   @override
@@ -154,71 +170,82 @@ class NakedTooltip extends StatefulWidget {
 }
 
 class _NakedTooltipState extends State<NakedTooltip> {
-  // ignore: dispose-fields
-  final _menuController = MenuController();
-  Timer? _showTimer;
-  Timer? _waitTimer;
+  TooltipPositionDelegate? _cachedPositionDelegate;
 
-  void _handleMouseEnter(PointerEnterEvent _) {
-    _showTimer?.cancel();
-    _waitTimer?.cancel();
-    _waitTimer = Timer(widget.waitDuration, () {
-      _menuController.open();
-    });
-  }
-
-  void _handleMouseExit(PointerExitEvent _) {
-    _showTimer?.cancel();
-    _waitTimer?.cancel();
-    _showTimer = Timer(widget.showDuration, () {
-      _menuController.close();
-    });
-  }
-
-  void _handleOpen() {
-    widget.onOpen?.call();
-  }
-
-  void _handleClose() {
-    widget.onClose?.call();
+  @override
+  void initState() {
+    super.initState();
+    _updatePositionDelegate();
   }
 
   @override
-  void dispose() {
-    _showTimer?.cancel();
-    _waitTimer?.cancel();
-    super.dispose();
+  void didUpdateWidget(NakedTooltip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.positioning != oldWidget.positioning ||
+        widget.positionDelegate != oldWidget.positionDelegate) {
+      _updatePositionDelegate();
+    }
+  }
+
+  void _updatePositionDelegate() {
+    if (widget.positionDelegate != null) {
+      _cachedPositionDelegate = widget.positionDelegate;
+      return;
+    }
+    if (widget.positioning == null) {
+      _cachedPositionDelegate = null;
+      return;
+    }
+    final config = widget.positioning!;
+    _cachedPositionDelegate = (TooltipPositionContext context) {
+      final targetTopLeft =
+          context.target - context.targetSize.center(Offset.zero);
+      final targetAnchorOffset = config.targetAnchor.alongSize(
+        context.targetSize,
+      );
+      final followerAnchorOffset = config.followerAnchor.alongSize(
+        context.tooltipSize,
+      );
+      final position =
+          targetTopLeft +
+          targetAnchorOffset -
+          followerAnchorOffset +
+          config.offset;
+
+      return Offset(
+        position.dx.clamp(
+          0.0,
+          (context.overlaySize.width - context.tooltipSize.width).clamp(
+            0.0,
+            double.infinity,
+          ),
+        ),
+        position.dy.clamp(
+          0.0,
+          (context.overlaySize.height - context.tooltipSize.height).clamp(
+            0.0,
+            double.infinity,
+          ),
+        ),
+      );
+    };
   }
 
   @override
   Widget build(BuildContext context) {
-    Widget tooltipContent = MouseRegion(
-      onEnter: _handleMouseEnter,
-      onExit: _handleMouseExit,
+    return RawTooltip(
+      semanticsTooltip: widget.excludeSemantics ? null : widget.semanticsLabel,
+      tooltipBuilder: widget.tooltipBuilder,
+      hoverDelay: widget.hoverDelay,
+      touchDelay: widget.touchDelay,
+      dismissDelay: widget.dismissDelay,
+      enableTapToDismiss: widget.enableTapToDismiss,
+      triggerMode: widget.triggerMode,
+      enableFeedback: widget.enableFeedback,
+      onTriggered: widget.onTriggered,
+      animationStyle: widget.animationStyle,
+      positionDelegate: _cachedPositionDelegate,
       child: widget.child,
-    );
-
-    Widget tooltipChild = widget.excludeSemantics
-        ? tooltipContent
-        : Semantics(
-            container: true,
-            tooltip: widget.semanticsLabel,
-            child: tooltipContent,
-          );
-
-    return RawMenuAnchor(
-      consumeOutsideTaps: false,
-      onOpen: _handleOpen,
-      onClose: _handleClose,
-      onOpenRequested: widget.onOpenRequested ?? (_, show) => show(),
-      onCloseRequested: widget.onCloseRequested ?? (hide) => hide(),
-      controller: _menuController,
-      overlayBuilder: (context, info) => OverlayPositioner(
-        targetRect: info.anchorRect,
-        positioning: widget.positioning,
-        child: widget.overlayBuilder(context, info),
-      ),
-      child: tooltipChild,
     );
   }
 }

--- a/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
@@ -59,10 +59,7 @@ void main() {
         return _buildTestApp(
           const Tooltip(
             message: 'Button tooltip',
-            child: ElevatedButton(
-              onPressed: null,
-              child: Text('Button'),
-            ),
+            child: ElevatedButton(onPressed: null, child: Text('Button')),
           ),
         );
       }
@@ -82,10 +79,7 @@ void main() {
                 style: TextStyle(color: Colors.white),
               ),
             ),
-            child: const NakedButton(
-              onPressed: null,
-              child: Text('Button'),
-            ),
+            child: const NakedButton(onPressed: null, child: Text('Button')),
           ),
         );
       }

--- a/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
@@ -21,8 +21,8 @@ void main() {
 
   Widget _buildNakedTooltip({required String message, required String child}) {
     return NakedTooltip(
-      semanticsLabel: message,
-      tooltipBuilder: (context, animation) => Container(
+      semanticLabel: message,
+      overlayBuilder: (context, animation) => Container(
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
           color: Colors.grey[800],
@@ -67,8 +67,8 @@ void main() {
       Widget buildNakedButtonWithTooltip() {
         return _buildTestApp(
           NakedTooltip(
-            semanticsLabel: 'Button tooltip',
-            tooltipBuilder: (context, animation) => Container(
+            semanticLabel: 'Button tooltip',
+            overlayBuilder: (context, animation) => Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
                 color: Colors.grey[800],
@@ -153,7 +153,7 @@ void main() {
       await tester.pumpWidget(
         _buildTestApp(
           NakedTooltip(
-            tooltipBuilder: (context, animation) =>
+            overlayBuilder: (context, animation) =>
                 const Text('Tooltip content'),
             child: const Text('No label'),
           ),

--- a/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tooltip_semantics_test.dart
@@ -22,7 +22,7 @@ void main() {
   Widget _buildNakedTooltip({required String message, required String child}) {
     return NakedTooltip(
       semanticsLabel: message,
-      overlayBuilder: (context, info) => Container(
+      tooltipBuilder: (context, animation) => Container(
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
           color: Colors.grey[800],
@@ -44,10 +44,8 @@ void main() {
         ),
       );
 
-      // Verify the basic structure exists
       expect(find.text('Trigger text'), findsOneWidget);
 
-      // Check semantics tree for tooltip semantics
       final triggerNode = tester.getSemantics(find.text('Trigger text'));
       expect(triggerNode, isNotNull);
 
@@ -62,7 +60,7 @@ void main() {
           const Tooltip(
             message: 'Button tooltip',
             child: ElevatedButton(
-              onPressed: null, // Disabled to simplify semantics
+              onPressed: null,
               child: Text('Button'),
             ),
           ),
@@ -73,7 +71,7 @@ void main() {
         return _buildTestApp(
           NakedTooltip(
             semanticsLabel: 'Button tooltip',
-            overlayBuilder: (context, info) => Container(
+            tooltipBuilder: (context, animation) => Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
                 color: Colors.grey[800],
@@ -85,7 +83,7 @@ void main() {
               ),
             ),
             child: const NakedButton(
-              onPressed: null, // Disabled to simplify semantics
+              onPressed: null,
               child: Text('Button'),
             ),
           ),
@@ -108,7 +106,6 @@ void main() {
       await mouse.addPointer();
       await tester.pump();
 
-      // Test with simple text triggers (not buttons)
       await tester.pumpWidget(
         _buildTestApp(
           _buildMaterialTooltip(message: 'Hover tooltip', child: 'Hover me'),
@@ -119,10 +116,8 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      // Verify Material tooltip appeared
       expect(find.text('Hover tooltip'), findsOneWidget);
 
-      // Test Naked tooltip
       await tester.pumpWidget(
         _buildTestApp(
           _buildNakedTooltip(message: 'Hover tooltip', child: 'Hover me'),
@@ -133,7 +128,6 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
-      // Verify both work similarly (this is a behavioral test rather than strict parity)
       expect(find.text('Hover me'), findsOneWidget);
 
       await mouse.removePointer();
@@ -165,13 +159,13 @@ void main() {
       await tester.pumpWidget(
         _buildTestApp(
           NakedTooltip(
-            overlayBuilder: (context, info) => const Text('Tooltip content'),
+            tooltipBuilder: (context, animation) =>
+                const Text('Tooltip content'),
             child: const Text('No label'),
           ),
         ),
       );
 
-      // Should still work without explicit semantics label
       expect(find.text('No label'), findsOneWidget);
       expect(
         tester.getSemantics(find.text('No label')),

--- a/packages/naked_ui/test/src/naked_tooltip_test.dart
+++ b/packages/naked_ui/test/src/naked_tooltip_test.dart
@@ -11,7 +11,7 @@ void main() {
       testWidgets('renders child widget', (WidgetTester tester) async {
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -24,7 +24,7 @@ void main() {
       ) async {
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -34,20 +34,19 @@ void main() {
     });
 
     group('Timer-based Show/Hide Behavior', () {
-      testWidgets('shows tooltip after waitDuration on mouse enter', (
+      testWidgets('shows tooltip after hoverDelay on mouse enter', (
         WidgetTester tester,
       ) async {
         const testKey = Key('test');
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            waitDuration: const Duration(milliseconds: 100),
-            showDuration: const Duration(seconds: 2),
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            hoverDelay: const Duration(milliseconds: 100),
+            dismissDelay: const Duration(seconds: 2),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
 
-        // Create mouse pointer and hover
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -57,36 +56,31 @@ void main() {
         await gesture.moveTo(center);
         await tester.pump();
 
-        // Tooltip should not appear immediately
         expect(find.text('Tooltip'), findsNothing);
 
-        // Advance past waitDuration
         await tester.pump(const Duration(milliseconds: 150));
         await tester.pumpAndSettle();
 
-        // Tooltip should now be visible
         expect(find.text('Tooltip'), findsOneWidget);
 
-        // Clean up
         await gesture.moveTo(const Offset(-1000, -1000));
         await tester.pumpAndSettle();
         await gesture.removePointer();
       });
 
-      testWidgets('hides tooltip after showDuration on mouse exit', (
+      testWidgets('hides tooltip after dismissDelay on mouse exit', (
         WidgetTester tester,
       ) async {
         const testKey = Key('test');
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            waitDuration: Duration.zero,
-            showDuration: const Duration(milliseconds: 100),
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            hoverDelay: Duration.zero,
+            dismissDelay: const Duration(milliseconds: 100),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
 
-        // Create mouse pointer and hover
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -96,181 +90,14 @@ void main() {
         await gesture.moveTo(center);
         await tester.pumpAndSettle();
 
-        // Tooltip should be visible
         expect(find.text('Tooltip'), findsOneWidget);
 
-        // Move pointer outside
         await gesture.moveTo(const Offset(-1000, -1000));
         await tester.pump();
 
-        // Tooltip should still be visible (before showDuration)
         expect(find.text('Tooltip'), findsOneWidget);
 
-        // Advance past showDuration
         await tester.pump(const Duration(milliseconds: 150));
-        await tester.pumpAndSettle();
-
-        // Tooltip should now be hidden
-        expect(find.text('Tooltip'), findsNothing);
-        await gesture.removePointer();
-      });
-    });
-
-    group('Callback Invocations', () {
-      testWidgets('calls onOpen when tooltip becomes visible', (
-        WidgetTester tester,
-      ) async {
-        const testKey = Key('test');
-        bool onOpenCalled = false;
-
-        await tester.pumpMaterialWidget(
-          NakedTooltip(
-            waitDuration: Duration.zero,
-            onOpen: () => onOpenCalled = true,
-            overlayBuilder: (context, info) => const Text('Tooltip'),
-            child: const SizedBox(key: testKey, width: 100, height: 100),
-          ),
-        );
-
-        expect(onOpenCalled, isFalse);
-
-        // Create mouse pointer and hover
-        final gesture = await tester.createGesture(
-          kind: PointerDeviceKind.mouse,
-        );
-        await gesture.addPointer();
-
-        final center = tester.getCenter(find.byKey(testKey));
-        await gesture.moveTo(center);
-        await tester.pumpAndSettle();
-
-        expect(onOpenCalled, isTrue);
-
-        // Clean up
-        await gesture.moveTo(const Offset(-1000, -1000));
-        await tester.pumpAndSettle();
-        await gesture.removePointer();
-      });
-
-      testWidgets('calls onClose when tooltip is hidden', (
-        WidgetTester tester,
-      ) async {
-        const testKey = Key('test');
-        bool onCloseCalled = false;
-
-        await tester.pumpMaterialWidget(
-          NakedTooltip(
-            waitDuration: Duration.zero,
-            showDuration: const Duration(milliseconds: 50),
-            onClose: () => onCloseCalled = true,
-            overlayBuilder: (context, info) => const Text('Tooltip'),
-            child: const SizedBox(key: testKey, width: 100, height: 100),
-          ),
-        );
-
-        // Create mouse pointer and hover
-        final gesture = await tester.createGesture(
-          kind: PointerDeviceKind.mouse,
-        );
-        await gesture.addPointer();
-
-        final center = tester.getCenter(find.byKey(testKey));
-        await gesture.moveTo(center);
-        await tester.pumpAndSettle();
-
-        expect(onCloseCalled, isFalse);
-
-        // Move pointer outside and wait for close
-        await gesture.moveTo(const Offset(-1000, -1000));
-        await tester.pump(const Duration(milliseconds: 100));
-        await tester.pumpAndSettle();
-
-        expect(onCloseCalled, isTrue);
-        await gesture.removePointer();
-      });
-
-      testWidgets('onOpenRequested can control show behavior', (
-        WidgetTester tester,
-      ) async {
-        const testKey = Key('test');
-        bool customShowCalled = false;
-
-        await tester.pumpMaterialWidget(
-          NakedTooltip(
-            waitDuration: Duration.zero,
-            onOpenRequested: (info, show) {
-              customShowCalled = true;
-              // Intentionally not calling show() to prevent tooltip from appearing
-            },
-            overlayBuilder: (context, info) => const Text('Tooltip'),
-            child: const SizedBox(key: testKey, width: 100, height: 100),
-          ),
-        );
-
-        // Create mouse pointer and hover
-        final gesture = await tester.createGesture(
-          kind: PointerDeviceKind.mouse,
-        );
-        await gesture.addPointer();
-
-        final center = tester.getCenter(find.byKey(testKey));
-        await gesture.moveTo(center);
-        await tester.pumpAndSettle();
-
-        expect(customShowCalled, isTrue);
-        // Tooltip should NOT appear because we didn't call show()
-        expect(find.text('Tooltip'), findsNothing);
-
-        // Clean up
-        await gesture.moveTo(const Offset(-1000, -1000));
-        await tester.pumpAndSettle();
-        await gesture.removePointer();
-      });
-
-      testWidgets('onCloseRequested can delay hide behavior', (
-        WidgetTester tester,
-      ) async {
-        const testKey = Key('test');
-        bool customHideCalled = false;
-        VoidCallback? storedHide;
-
-        await tester.pumpMaterialWidget(
-          NakedTooltip(
-            waitDuration: Duration.zero,
-            showDuration: Duration.zero,
-            onCloseRequested: (hide) {
-              customHideCalled = true;
-              storedHide = hide;
-              // Intentionally not calling hide() immediately
-            },
-            overlayBuilder: (context, info) => const Text('Tooltip'),
-            child: const SizedBox(key: testKey, width: 100, height: 100),
-          ),
-        );
-
-        // Create mouse pointer and hover
-        final gesture = await tester.createGesture(
-          kind: PointerDeviceKind.mouse,
-        );
-        await gesture.addPointer();
-
-        final center = tester.getCenter(find.byKey(testKey));
-        await gesture.moveTo(center);
-        await tester.pumpAndSettle();
-
-        expect(find.text('Tooltip'), findsOneWidget);
-
-        // Move pointer outside
-        await gesture.moveTo(const Offset(-1000, -1000));
-        await tester.pump(const Duration(milliseconds: 50));
-        await tester.pumpAndSettle();
-
-        expect(customHideCalled, isTrue);
-        // Tooltip should still be visible because we didn't call hide()
-        expect(find.text('Tooltip'), findsOneWidget);
-
-        // Now call hide
-        storedHide?.call();
         await tester.pumpAndSettle();
 
         expect(find.text('Tooltip'), findsNothing);
@@ -286,13 +113,12 @@ void main() {
 
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            waitDuration: const Duration(milliseconds: 100),
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            hoverDelay: const Duration(milliseconds: 100),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
 
-        // Create mouse pointer
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -300,16 +126,13 @@ void main() {
 
         final center = tester.getCenter(find.byKey(testKey));
 
-        // Move in
         await gesture.moveTo(center);
         await tester.pump(const Duration(milliseconds: 50));
 
-        // Move out before waitDuration completes
         await gesture.moveTo(const Offset(-1000, -1000));
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        // Tooltip should NOT appear because we exited before waitDuration
         expect(find.text('Tooltip'), findsNothing);
         await gesture.removePointer();
       });
@@ -321,14 +144,13 @@ void main() {
 
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            waitDuration: Duration.zero,
-            showDuration: const Duration(milliseconds: 100),
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            hoverDelay: Duration.zero,
+            dismissDelay: const Duration(milliseconds: 100),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
 
-        // Create mouse pointer
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -336,24 +158,19 @@ void main() {
 
         final center = tester.getCenter(find.byKey(testKey));
 
-        // Hover to show tooltip
         await gesture.moveTo(center);
         await tester.pumpAndSettle();
         expect(find.text('Tooltip'), findsOneWidget);
 
-        // Move out briefly
         await gesture.moveTo(const Offset(-1000, -1000));
         await tester.pump(const Duration(milliseconds: 50));
 
-        // Move back in before showDuration completes
         await gesture.moveTo(center);
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        // Tooltip should still be visible because we re-entered
         expect(find.text('Tooltip'), findsOneWidget);
 
-        // Clean up
         await gesture.moveTo(const Offset(-1000, -1000));
         await tester.pumpAndSettle();
         await gesture.removePointer();
@@ -361,22 +178,19 @@ void main() {
     });
 
     group('Widget Disposal', () {
-      testWidgets('disposes timers when widget is removed', (
+      testWidgets('cleans up when widget is removed', (
         WidgetTester tester,
       ) async {
         const testKey = Key('test');
-        bool onOpenCalled = false;
 
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            waitDuration: const Duration(milliseconds: 100),
-            onOpen: () => onOpenCalled = true,
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            hoverDelay: const Duration(milliseconds: 100),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
 
-        // Create mouse pointer and hover
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -386,15 +200,12 @@ void main() {
         await gesture.moveTo(center);
         await tester.pump(const Duration(milliseconds: 50));
 
-        // Replace widget before waitDuration completes
         await tester.pumpMaterialWidget(const SizedBox.shrink());
 
-        // Advance timer past original waitDuration
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        // onOpen should NOT be called because widget was disposed
-        expect(onOpenCalled, isFalse);
+        expect(find.text('Tooltip'), findsNothing);
         await gesture.removePointer();
       });
     });
@@ -408,7 +219,7 @@ void main() {
         await tester.pumpMaterialWidget(
           NakedTooltip(
             semanticsLabel: 'Help text',
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -427,13 +238,12 @@ void main() {
           NakedTooltip(
             semanticsLabel: 'Help text',
             excludeSemantics: true,
-            overlayBuilder: (context, info) => const Text('Tooltip'),
+            tooltipBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
 
         final semantics = tester.getSemantics(find.text('Hover me'));
-        // When excludeSemantics is true, tooltip should be empty or null
         expect(semantics.tooltip, anyOf(isNull, isEmpty));
         handle.dispose();
       });
@@ -448,13 +258,13 @@ void main() {
         await tester.pumpMaterialWidget(
           Center(
             child: NakedTooltip(
-              waitDuration: Duration.zero,
+              hoverDelay: Duration.zero,
               positioning: const OverlayPositionConfig(
                 targetAnchor: Alignment.bottomCenter,
                 followerAnchor: Alignment.topCenter,
                 offset: Offset(0, 8),
               ),
-              overlayBuilder: (context, info) => Container(
+              tooltipBuilder: (context, animation) => Container(
                 key: const Key('tooltip'),
                 color: Colors.black,
                 child: const Text('Tooltip'),
@@ -464,7 +274,6 @@ void main() {
           ),
         );
 
-        // Create mouse pointer and hover
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -474,14 +283,47 @@ void main() {
         await gesture.moveTo(center);
         await tester.pumpAndSettle();
 
-        // Tooltip should appear below the child
         final childBox = tester.getRect(find.byKey(testKey));
         final tooltipBox = tester.getRect(find.byKey(const Key('tooltip')));
 
-        // Tooltip top should be below child bottom (accounting for offset)
         expect(tooltipBox.top, greaterThanOrEqualTo(childBox.bottom));
 
-        // Clean up
+        await gesture.moveTo(const Offset(-1000, -1000));
+        await tester.pumpAndSettle();
+        await gesture.removePointer();
+      });
+    });
+
+    group('Animation', () {
+      testWidgets('provides animation to tooltipBuilder', (
+        WidgetTester tester,
+      ) async {
+        const testKey = Key('test');
+        Animation<double>? receivedAnimation;
+
+        await tester.pumpMaterialWidget(
+          NakedTooltip(
+            hoverDelay: Duration.zero,
+            tooltipBuilder: (context, animation) {
+              receivedAnimation = animation;
+              return const Text('Tooltip');
+            },
+            child: const SizedBox(key: testKey, width: 100, height: 100),
+          ),
+        );
+
+        final gesture = await tester.createGesture(
+          kind: PointerDeviceKind.mouse,
+        );
+        await gesture.addPointer();
+
+        final center = tester.getCenter(find.byKey(testKey));
+        await gesture.moveTo(center);
+        await tester.pumpAndSettle();
+
+        expect(receivedAnimation, isNotNull);
+        expect(receivedAnimation!.value, 1.0);
+
         await gesture.moveTo(const Offset(-1000, -1000));
         await tester.pumpAndSettle();
         await gesture.removePointer();

--- a/packages/naked_ui/test/src/naked_tooltip_test.dart
+++ b/packages/naked_ui/test/src/naked_tooltip_test.dart
@@ -11,7 +11,7 @@ void main() {
       testWidgets('renders child widget', (WidgetTester tester) async {
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -24,7 +24,7 @@ void main() {
       ) async {
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -42,7 +42,7 @@ void main() {
           NakedTooltip(
             hoverDelay: const Duration(milliseconds: 100),
             dismissDelay: const Duration(seconds: 2),
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
@@ -76,7 +76,7 @@ void main() {
           NakedTooltip(
             hoverDelay: Duration.zero,
             dismissDelay: const Duration(milliseconds: 100),
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
@@ -114,7 +114,7 @@ void main() {
         await tester.pumpMaterialWidget(
           NakedTooltip(
             hoverDelay: const Duration(milliseconds: 100),
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
@@ -146,7 +146,7 @@ void main() {
           NakedTooltip(
             hoverDelay: Duration.zero,
             dismissDelay: const Duration(milliseconds: 100),
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
@@ -186,7 +186,7 @@ void main() {
         await tester.pumpMaterialWidget(
           NakedTooltip(
             hoverDelay: const Duration(milliseconds: 100),
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const SizedBox(key: testKey, width: 100, height: 100),
           ),
         );
@@ -218,8 +218,8 @@ void main() {
 
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            semanticsLabel: 'Help text',
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            semanticLabel: 'Help text',
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -236,9 +236,9 @@ void main() {
 
         await tester.pumpMaterialWidget(
           NakedTooltip(
-            semanticsLabel: 'Help text',
+            semanticLabel: 'Help text',
             excludeSemantics: true,
-            tooltipBuilder: (context, animation) => const Text('Tooltip'),
+            overlayBuilder: (context, animation) => const Text('Tooltip'),
             child: const Text('Hover me'),
           ),
         );
@@ -264,7 +264,7 @@ void main() {
                 followerAnchor: Alignment.topCenter,
                 offset: Offset(0, 8),
               ),
-              tooltipBuilder: (context, animation) => Container(
+              overlayBuilder: (context, animation) => Container(
                 key: const Key('tooltip'),
                 color: Colors.black,
                 child: const Text('Tooltip'),
@@ -295,7 +295,7 @@ void main() {
     });
 
     group('Animation', () {
-      testWidgets('provides animation to tooltipBuilder', (
+      testWidgets('provides animation to overlayBuilder', (
         WidgetTester tester,
       ) async {
         const testKey = Key('test');
@@ -304,7 +304,7 @@ void main() {
         await tester.pumpMaterialWidget(
           NakedTooltip(
             hoverDelay: Duration.zero,
-            tooltipBuilder: (context, animation) {
+            overlayBuilder: (context, animation) {
               receivedAnimation = animation;
               return const Text('Tooltip');
             },


### PR DESCRIPTION
## Summary

- **Replaces `RawMenuAnchor` with `RawTooltip`** as the underlying primitive for `NakedTooltip`, gaining built-in animation, touch/mobile triggers, exclusive nested tooltips, and global dismiss for free.
- **Simplifies the builder API**: `overlayBuilder(context, info)` → `tooltipBuilder(context, animation)` — the animation drives show/hide transitions directly, eliminating the need for manual `AnimationController` setup.
- **Removes lifecycle callbacks** (`onOpen`, `onClose`, `onOpenRequested`, `onCloseRequested`) that were tied to the `RawMenuAnchor` model.

### Breaking API changes

| Old | New |
|---|---|
| `overlayBuilder: (ctx, info) =>` | `tooltipBuilder: (ctx, animation) =>` |
| `waitDuration` | `hoverDelay` |
| `showDuration` | `dismissDelay` |
| `onOpen` / `onClose` | removed |
| `onOpenRequested` / `onCloseRequested` | removed |

### New parameters (from RawTooltip)

- `triggerMode` — longPress, tap, or manual touch triggers
- `touchDelay` — how long tooltip stays after touch release
- `enableTapToDismiss` — dismiss on outside tap
- `enableFeedback` — haptic/acoustic feedback
- `onTriggered` — callback for touch triggers
- `animationStyle` — control animation duration/curve
- `positionDelegate` — alternative to `OverlayPositionConfig`

## Open question

9 out of 13 parameters are now pure pass-through to `RawTooltip` with zero transformation. The only real value `NakedTooltip` adds is:

1. The `OverlayPositionConfig` → `TooltipPositionDelegate` conversion (shared positioning model with other naked_ui widgets)
2. The `semanticsLabel`/`excludeSemantics` → `semanticsTooltip` mapping

**Is it worth keeping as a separate widget, or should it just be a convenience extension or dropped?** `RawTooltip` was added in Flutter 3.41, so users on that version or later can use it directly.

## Test plan

- [x] All 528 unit + semantics tests pass
- [x] Updated example to use new stateless pattern (no more manual AnimationController)
- [x] Updated integration tests
- [x] Updated documentation