### PR TITLE
feat(naked-select): add mouseCursor property to NakedSelect

### DIFF
--- a/packages/naked_ui/lib/src/naked_select.dart
+++ b/packages/naked_ui/lib/src/naked_select.dart
@@ -226,6 +226,7 @@ class NakedSelect<T> extends StatefulWidget {
     this.closeOnSelect = true,
     this.closeOnClickOutside = true,
     this.enabled = true,
+    this.mouseCursor = SystemMouseCursors.click,
     this.triggerFocusNode,
     this.semanticLabel,
     this.positioning = const OverlayPositionConfig(
@@ -271,6 +272,12 @@ class NakedSelect<T> extends StatefulWidget {
 
   /// Whether the select is interactive.
   final bool enabled;
+
+  /// The mouse cursor for the trigger when the select is interactive.
+  ///
+  /// Defaults to [SystemMouseCursors.click]. When the select is disabled, the
+  /// trigger falls back to [SystemMouseCursors.basic].
+  final MouseCursor mouseCursor;
 
   /// Focus node for the trigger.
   final FocusNode? triggerFocusNode;
@@ -410,6 +417,7 @@ class _NakedSelectState<T> extends State<NakedSelect<T>>
       child: NakedButton(
         onPressed: widget.enabled ? _toggle : null,
         enabled: widget.enabled,
+        mouseCursor: widget.mouseCursor,
         focusNode: widget.triggerFocusNode,
         excludeSemantics: true,
         child: widget.child,

--- a/packages/naked_ui/test/src/naked_select_test.dart
+++ b/packages/naked_ui/test/src/naked_select_test.dart
@@ -1023,4 +1023,52 @@ void main() {
       expect(isSelected, isTrue);
     });
   });
+
+  group('Cursor', () {
+    testWidgets('shows appropriate cursor based on interactive state', (
+      WidgetTester tester,
+    ) async {
+      final keyEnabled = UniqueKey();
+      final keyDisabled = UniqueKey();
+
+      await tester.pumpMaterialWidget(
+        Column(
+          children: [
+            NakedSelect<String>(
+              key: keyEnabled,
+              onChanged: (_) {},
+              builder: (context, state, child) => const Text('Enabled'),
+              overlayBuilder: (context, info) => const SizedBox(),
+            ),
+            NakedSelect<String>(
+              key: keyDisabled,
+              enabled: false,
+              onChanged: (_) {},
+              builder: (context, state, child) => const Text('Disabled'),
+              overlayBuilder: (context, info) => const SizedBox(),
+            ),
+          ],
+        ),
+      );
+
+      tester.expectCursor(SystemMouseCursors.click, on: keyEnabled);
+      tester.expectCursor(SystemMouseCursors.basic, on: keyDisabled);
+    });
+
+    testWidgets('supports custom cursor', (WidgetTester tester) async {
+      final key = UniqueKey();
+
+      await tester.pumpMaterialWidget(
+        NakedSelect<String>(
+          key: key,
+          onChanged: (_) {},
+          mouseCursor: SystemMouseCursors.help,
+          builder: (context, state, child) => const Text('Custom Cursor'),
+          overlayBuilder: (context, info) => const SizedBox(),
+        ),
+      );
+
+      tester.expectCursor(SystemMouseCursors.help, on: key);
+    });
+  });
 }


### PR DESCRIPTION
## Description

`NakedSelect` previously had no way to customize the mouse cursor over its trigger — it was hard-coded to the underlying `NakedButton` default (`SystemMouseCursors.click`). This PR adds a `mouseCursor` property to `NakedSelect` that is forwarded to the trigger button, defaulting to `SystemMouseCursors.click` and falling back to `SystemMouseCursors.basic` when the select is disabled. This brings `NakedSelect` in line with sibling widgets like `NakedButton` and `NakedCheckbox` that already expose `mouseCursor`.

## Related Issues

*N/A*

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.