### PR TITLE
fix(naked-ui): stabilize flaky tests (InkSparkle shader + focus mode)

### DIFF
--- a/packages/naked_ui/test/semantics/naked_button_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_button_semantics_test.dart
@@ -10,6 +10,7 @@ import 'semantics_test_utils.dart';
 void main() {
   Widget _buildTestApp(Widget child) {
     return MaterialApp(
+      theme: ThemeData(splashFactory: NoSplash.splashFactory),
       home: Scaffold(body: Center(child: child)),
     );
   }

--- a/packages/naked_ui/test/semantics/naked_dialog_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_dialog_semantics_test.dart
@@ -8,6 +8,7 @@ import 'semantics_test_utils.dart';
 void main() {
   Widget _buildTestApp(Widget child) {
     return MaterialApp(
+      theme: ThemeData(splashFactory: NoSplash.splashFactory),
       home: Scaffold(body: Center(child: child)),
     );
   }
@@ -20,6 +21,7 @@ void main() {
   }) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
         home: Scaffold(
           body: Builder(
             builder: (context) => ElevatedButton(

--- a/packages/naked_ui/test/semantics/naked_slider_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_slider_semantics_test.dart
@@ -77,6 +77,11 @@ void main() {
 
     testWidgets('focus parity', (tester) async {
       final handle = tester.ensureSemantics();
+      // Force traditional focus highlight so Material exposes `isFocused`
+      // in semantics consistently regardless of any pointer events that ran
+      // in earlier tests in the same suite.
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
       final fm = FocusNode();
       final fn = FocusNode();
 

--- a/packages/naked_ui/test/src/naked_dialog_test.dart
+++ b/packages/naked_ui/test/src/naked_dialog_test.dart
@@ -12,6 +12,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            theme: ThemeData(splashFactory: NoSplash.splashFactory),
             home: Builder(
               builder: (ctx) => Scaffold(
                 body: Center(

--- a/packages/naked_ui/test/test_helpers.dart
+++ b/packages/naked_ui/test/test_helpers.dart
@@ -7,7 +7,15 @@ import 'package:flutter_test/flutter_test.dart';
 
 extension WidgetTesterExtension on WidgetTester {
   Future<void> pumpMaterialWidget(Widget widget) async {
-    await pumpWidget(MaterialApp(home: Scaffold(body: widget)));
+    await pumpWidget(
+      MaterialApp(
+        // Avoid loading the InkSparkle fragment shader, which can fail to
+        // decode in some test environments and surface as
+        // `Unsupported runtime stages format version` exceptions.
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
+        home: Scaffold(body: widget),
+      ),
+    );
   }
 
   /// Simulates hover more robustly by moving a mouse pointer to the center of

--- a/packages/naked_ui/test/utilities/naked_state_scope_test.dart
+++ b/packages/naked_ui/test/utilities/naked_state_scope_test.dart
@@ -46,6 +46,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(splashFactory: NoSplash.splashFactory),
           home: StatefulBuilder(
             builder: (context, setState) {
               return Scaffold(
@@ -104,6 +105,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(splashFactory: NoSplash.splashFactory),
           home: NakedStateScope<TestNakedState>(
             value: testState,
             child: StatefulBuilder(


### PR DESCRIPTION
## Summary
- Eight tests failed intermittently when running the full suite. Two distinct root causes:
  - **InkSparkle shader load failure** — `tap()` on Material `ElevatedButton`/`TextButton` triggers `FragmentProgram.fromAsset('shaders/ink_sparkle.frag')`, which in this environment throws `Unsupported runtime stages format version. Expected 2, got 1.` Affected 7 tests across `naked_button_semantics`, `naked_dialog_semantics`, `naked_dialog_test`, `naked_state_scope_test`, and the parity tests routed through `pumpMaterialWidget`. Fix: opt those `MaterialApp`s into `ThemeData(splashFactory: NoSplash.splashFactory)`.
  - **Slider focus-parity flake** — earlier tests in the suite drift `FocusManager` into `touch` highlight mode (its `highlightStrategy` is `automatic`, not the `alwaysTraditional` set by `flutter_test_config.dart`). In `touch` mode Material `Slider` omits the `isFocused` flag while `NakedSlider` still reports it, breaking the set-equality assertion. Fix: force `FocusHighlightStrategy.alwaysTraditional` at the top of the focus-parity test.

## Test plan
- [x] `flutter test` — 530/530 pass locally.
- [x] `flutter test test/semantics/naked_slider_semantics_test.dart` passes in isolation and as part of the full run.
- [x] No production code changed; fix is scoped to test files and `test_helpers.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)