### PR TITLE
chore(naked-ui): bump version to 1.0.0-beta.1

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-beta.1
+
+- feat(naked-select): add `mouseCursor` property to NakedSelect
+- refactor(naked-tooltip): replace `RawMenuAnchor` with `RawTooltip`
+- fix: stabilize flaky tests (InkSparkle shader + focus mode)
+
 ## 0.2.0-beta.7
 
 - fix: text style handling in NakedTextField

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/btwld/naked_ui
 documentation: https://docs.page/btwld/naked_ui
 issue_tracker: https://github.com/btwld/naked_ui/issues
 license: BSD-3-Clause
-version: 0.2.0-beta.7
+version: 1.0.0-beta.1
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Summary
- Bump `naked_ui` version from `0.2.0-beta.7` to `1.0.0-beta.1`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)