### PR TITLE
fix(naked-tabs): one onChanged per press in controlled mode; semanticLabel replaces content semantics

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Unreleased
 
-- fix: NakedTabs in controlled mode (`selectedTabId` + `onChanged`) no longer
-  fires `onChanged` twice for one tab press. Focusing a tab selects it
-  (selection follows focus) and the tap that caused the focus selected it
-  again; hosts that commit asynchronously now receive one call per requested
-  change.
+- fix: one tab press no longer dispatches selection twice. A press selected
+  directly and again when its requested focus landed (selection follows
+  focus); the focus-driven duplicate is now suppressed inside `NakedTab`, so
+  controlled hosts that commit asynchronously receive one `onChanged` per
+  press, and retries — including keyboard Enter/Space on a host that rejects
+  the change — always fire.
 - fix: an explicit `NakedTab.semanticLabel` now replaces the content's
   semantics instead of concatenating with them, so a tab whose content renders
   the same text is announced once.

--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+- fix: NakedTabs in controlled mode (`selectedTabId` + `onChanged`) no longer
+  fires `onChanged` twice for one tab press. Focusing a tab selects it
+  (selection follows focus) and the tap that caused the focus selected it
+  again; hosts that commit asynchronously now receive one call per requested
+  change.
+- fix: an explicit `NakedTab.semanticLabel` now replaces the content's
+  semantics instead of concatenating with them, so a tab whose content renders
+  the same text is announced once.
+
 ## 1.0.0-beta.1
 
 - feat(naked-select): add `mouseCursor` property to NakedSelect

--- a/packages/naked_ui/lib/src/naked_tabs.dart
+++ b/packages/naked_ui/lib/src/naked_tabs.dart
@@ -99,7 +99,7 @@ class NakedTabState extends NakedState {
 /// - [TabBar], the Material-styled tabs widget for typical apps.
 /// - [FocusTraversalGroup], for customizing keyboard focus traversal.
 
-class NakedTabs extends StatefulWidget {
+class NakedTabs extends StatelessWidget {
   const NakedTabs({
     super.key,
     required this.child,
@@ -141,43 +141,20 @@ class NakedTabs extends StatefulWidget {
   /// Called when Escape is pressed while a tab has focus.
   final VoidCallback? onEscapePressed;
 
-  @override
-  State<NakedTabs> createState() => _NakedTabsState();
-}
-
-class _NakedTabsState extends State<NakedTabs> {
-  /// Tab id already forwarded to [NakedTabs.onChanged] in the current frame.
-  ///
-  /// One press can request the same selection twice — focusing a tab selects it
-  /// (selection follows focus) and the tap that caused the focus selects it
-  /// again. With a controller the second call is a no-op because the controller
-  /// updates synchronously, but a controlled host may commit asynchronously.
-  /// The guard lasts for one frame so it collapses the focus and tap paths from
-  /// one press without suppressing a later press if the host rejects or delays
-  /// the requested selection.
-  String? _requestedTabIdThisFrame;
-
   String get _effectiveSelectedTabId =>
-      widget.controller?.selectedTabId ?? widget.selectedTabId!;
+      controller?.selectedTabId ?? selectedTabId!;
 
   bool get _effectiveEnabled =>
-      widget.enabled && (widget.controller != null || widget.onChanged != null);
+      enabled && (controller != null || onChanged != null);
 
   void _selectTab(String tabId) {
     if (!_effectiveEnabled || tabId == _effectiveSelectedTabId) return;
     assert(tabId.isNotEmpty, 'Tab ID cannot be empty');
 
-    if (widget.controller != null) {
-      widget.controller!.selectTab(tabId);
+    if (controller != null) {
+      controller!.selectTab(tabId);
     } else {
-      if (tabId == _requestedTabIdThisFrame) return;
-      _requestedTabIdThisFrame = tabId;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _requestedTabIdThisFrame == tabId) {
-          _requestedTabIdThisFrame = null;
-        }
-      });
-      widget.onChanged?.call(tabId);
+      onChanged?.call(tabId);
     }
   }
 
@@ -188,16 +165,16 @@ class _NakedTabsState extends State<NakedTabs> {
     return Actions(
       actions: {
         DismissIntent: CallbackAction<DismissIntent>(
-          onInvoke: (_) => widget.onEscapePressed?.call(),
+          onInvoke: (_) => onEscapePressed?.call(),
         ),
       },
       child: NakedTabsScope(
         selectedTabId: _effectiveSelectedTabId,
         onChanged: _selectTab,
-        orientation: widget.orientation,
+        orientation: orientation,
         enabled: _effectiveEnabled,
-        onEscapePressed: widget.onEscapePressed,
-        child: widget.child,
+        onEscapePressed: onEscapePressed,
+        child: child,
       ),
     );
   }
@@ -360,10 +337,29 @@ class _NakedTabState extends State<NakedTab>
       ..skipTraversal = !_isEnabled;
   }
 
+  /// True while a focus-gain event caused by this tab's own tap/activation
+  /// is in flight; the next focus event on this tab consumes it.
+  ///
+  /// A press would otherwise dispatch selection twice: [_handleTap] selects
+  /// directly and the focus it requests selects again (selection follows
+  /// focus). The direct call must stay — a press selects synchronously, even
+  /// when focus cannot move — so the focus-driven follow-up is the one
+  /// suppressed. Deliberately not frame- or timer-scoped: a controlled host
+  /// that rejects a change schedules no frame, and a frame-scoped guard would
+  /// swallow keyboard retries. The flag is armed only when the tap will
+  /// actually produce a focus event and consumed on the next event either
+  /// way, so at worst (requested focus preempted before landing here) it
+  /// suppresses one focus-follow selection and self-heals; a press's own
+  /// selection is never lost.
+  bool _selectionRequestedByTap = false;
+
   void _handleTap() {
     if (!_isEnabled) return;
     if (widget.enableFeedback) HapticFeedback.selectionClick();
     if (effectiveFocusNode.canRequestFocus) {
+      // requestFocus on an already-focused node emits no focus event and
+      // would leave the flag stale; only arm it when an event will consume it.
+      _selectionRequestedByTap = !effectiveFocusNode.hasPrimaryFocus;
       effectiveFocusNode.requestFocus();
     }
     _scope.selectTab(widget.tabId);
@@ -496,11 +492,14 @@ class _NakedTabState extends State<NakedTab>
       enabled: _isEnabled,
       autofocus: widget.autofocus,
       onFocusChange: (f) {
+        final selectedByTap = _selectionRequestedByTap;
+        _selectionRequestedByTap = false;
+        // updateFocusState already rebuilds on every real focus transition,
+        // which is the only way Focus.onFocusChange fires.
         updateFocusState(f, widget.onFocusChange);
-        if (f && _isEnabled) {
+        if (f && _isEnabled && !selectedByTap) {
           _scope.selectTab(widget.tabId);
         }
-        setState(() {});
       },
       onHoverChange: (h) => updateHoverState(h, widget.onHoverChange),
       focusNode: effectiveFocusNode,

--- a/packages/naked_ui/lib/src/naked_tabs.dart
+++ b/packages/naked_ui/lib/src/naked_tabs.dart
@@ -146,30 +146,22 @@ class NakedTabs extends StatefulWidget {
 }
 
 class _NakedTabsState extends State<NakedTabs> {
-  /// Tab id already forwarded to [NakedTabs.onChanged] that the host has not
-  /// yet committed back through [NakedTabs.selectedTabId].
+  /// Tab id already forwarded to [NakedTabs.onChanged] in the current frame.
   ///
   /// One press can request the same selection twice — focusing a tab selects it
   /// (selection follows focus) and the tap that caused the focus selects it
   /// again. With a controller the second call is a no-op because the controller
-  /// updates synchronously, but a controlled host may commit asynchronously, so
-  /// without this guard it would receive two [NakedTabs.onChanged] calls for
-  /// one press.
-  String? _pendingTabId;
+  /// updates synchronously, but a controlled host may commit asynchronously.
+  /// The guard lasts for one frame so it collapses the focus and tap paths from
+  /// one press without suppressing a later press if the host rejects or delays
+  /// the requested selection.
+  String? _requestedTabIdThisFrame;
 
   String get _effectiveSelectedTabId =>
       widget.controller?.selectedTabId ?? widget.selectedTabId!;
 
   bool get _effectiveEnabled =>
       widget.enabled && (widget.controller != null || widget.onChanged != null);
-
-  @override
-  void didUpdateWidget(covariant NakedTabs oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.selectedTabId != oldWidget.selectedTabId) {
-      _pendingTabId = null;
-    }
-  }
 
   void _selectTab(String tabId) {
     if (!_effectiveEnabled || tabId == _effectiveSelectedTabId) return;
@@ -178,8 +170,13 @@ class _NakedTabsState extends State<NakedTabs> {
     if (widget.controller != null) {
       widget.controller!.selectTab(tabId);
     } else {
-      if (tabId == _pendingTabId) return;
-      _pendingTabId = tabId;
+      if (tabId == _requestedTabIdThisFrame) return;
+      _requestedTabIdThisFrame = tabId;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _requestedTabIdThisFrame == tabId) {
+          _requestedTabIdThisFrame = null;
+        }
+      });
       widget.onChanged?.call(tabId);
     }
   }

--- a/packages/naked_ui/lib/src/naked_tabs.dart
+++ b/packages/naked_ui/lib/src/naked_tabs.dart
@@ -293,9 +293,9 @@ class NakedTab extends StatefulWidget {
 
   /// Semantic label for the trigger.
   ///
-  /// When provided it replaces the semantics of the tab's content, so a tab
-  /// whose content already renders the same text is announced once. When null
-  /// the content's own semantics are used.
+  /// When provided, it replaces the semantics of the tab's content, so a tab
+  /// whose content already renders the same text is announced once. When
+  /// null, the content's own semantics are used.
   final String? semanticLabel;
 
   /// Whether the tab is enabled.
@@ -337,20 +337,19 @@ class _NakedTabState extends State<NakedTab>
       ..skipTraversal = !_isEnabled;
   }
 
-  /// True while a focus-gain event caused by this tab's own tap/activation
-  /// is in flight; the next focus event on this tab consumes it.
+  /// Whether a focus-gain event caused by this tab's own tap or keyboard
+  /// activation is in flight.
   ///
   /// A press would otherwise dispatch selection twice: [_handleTap] selects
-  /// directly and the focus it requests selects again (selection follows
+  /// directly, and the focus it requests selects again (selection follows
   /// focus). The direct call must stay — a press selects synchronously, even
   /// when focus cannot move — so the focus-driven follow-up is the one
-  /// suppressed. Deliberately not frame- or timer-scoped: a controlled host
-  /// that rejects a change schedules no frame, and a frame-scoped guard would
-  /// swallow keyboard retries. The flag is armed only when the tap will
-  /// actually produce a focus event and consumed on the next event either
-  /// way, so at worst (requested focus preempted before landing here) it
-  /// suppresses one focus-follow selection and self-heals; a press's own
-  /// selection is never lost.
+  /// suppressed; the next focus event on this tab consumes the flag either
+  /// way. Deliberately not frame- or timer-scoped: a controlled host that
+  /// rejects a change schedules no frame, and a frame-scoped guard would
+  /// swallow keyboard retries. At worst (requested focus preempted before
+  /// landing here) a stale flag suppresses one focus-follow selection and
+  /// self-heals; a press's own selection is never lost.
   bool _selectionRequestedByTap = false;
 
   void _handleTap() {
@@ -480,9 +479,10 @@ class _NakedTabState extends State<NakedTab>
             selected: isSelected,
             button: true,
             label: widget.semanticLabel,
-            // An explicit label replaces the content's semantics; without this
-            // a tab whose content renders the same text is announced twice.
-            // When no label is given the content's own semantics flow through.
+            // An explicit label replaces the content's semantics; without
+            // this, a tab whose content renders the same text is announced
+            // twice. When no label is given, the content's own semantics flow
+            // through.
             excludeSemantics: widget.semanticLabel != null,
             onTap: _isEnabled ? _handleTap : null,
             child: gestureDetector,
@@ -494,8 +494,9 @@ class _NakedTabState extends State<NakedTab>
       onFocusChange: (f) {
         final selectedByTap = _selectionRequestedByTap;
         _selectionRequestedByTap = false;
-        // updateFocusState already rebuilds on every real focus transition,
-        // which is the only way Focus.onFocusChange fires.
+        // No setState here: updateFocusState already rebuilds on every real
+        // focus transition, and transitions are the only way
+        // Focus.onFocusChange fires.
         updateFocusState(f, widget.onFocusChange);
         if (f && _isEnabled && !selectedByTap) {
           _scope.selectTab(widget.tabId);

--- a/packages/naked_ui/lib/src/naked_tabs.dart
+++ b/packages/naked_ui/lib/src/naked_tabs.dart
@@ -99,7 +99,7 @@ class NakedTabState extends NakedState {
 /// - [TabBar], the Material-styled tabs widget for typical apps.
 /// - [FocusTraversalGroup], for customizing keyboard focus traversal.
 
-class NakedTabs extends StatelessWidget {
+class NakedTabs extends StatefulWidget {
   const NakedTabs({
     super.key,
     required this.child,
@@ -141,20 +141,46 @@ class NakedTabs extends StatelessWidget {
   /// Called when Escape is pressed while a tab has focus.
   final VoidCallback? onEscapePressed;
 
+  @override
+  State<NakedTabs> createState() => _NakedTabsState();
+}
+
+class _NakedTabsState extends State<NakedTabs> {
+  /// Tab id already forwarded to [NakedTabs.onChanged] that the host has not
+  /// yet committed back through [NakedTabs.selectedTabId].
+  ///
+  /// One press can request the same selection twice — focusing a tab selects it
+  /// (selection follows focus) and the tap that caused the focus selects it
+  /// again. With a controller the second call is a no-op because the controller
+  /// updates synchronously, but a controlled host may commit asynchronously, so
+  /// without this guard it would receive two [NakedTabs.onChanged] calls for
+  /// one press.
+  String? _pendingTabId;
+
   String get _effectiveSelectedTabId =>
-      controller?.selectedTabId ?? selectedTabId!;
+      widget.controller?.selectedTabId ?? widget.selectedTabId!;
 
   bool get _effectiveEnabled =>
-      enabled && (controller != null || onChanged != null);
+      widget.enabled && (widget.controller != null || widget.onChanged != null);
+
+  @override
+  void didUpdateWidget(covariant NakedTabs oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.selectedTabId != oldWidget.selectedTabId) {
+      _pendingTabId = null;
+    }
+  }
 
   void _selectTab(String tabId) {
     if (!_effectiveEnabled || tabId == _effectiveSelectedTabId) return;
     assert(tabId.isNotEmpty, 'Tab ID cannot be empty');
 
-    if (controller != null) {
-      controller!.selectTab(tabId);
+    if (widget.controller != null) {
+      widget.controller!.selectTab(tabId);
     } else {
-      onChanged?.call(tabId);
+      if (tabId == _pendingTabId) return;
+      _pendingTabId = tabId;
+      widget.onChanged?.call(tabId);
     }
   }
 
@@ -165,16 +191,16 @@ class NakedTabs extends StatelessWidget {
     return Actions(
       actions: {
         DismissIntent: CallbackAction<DismissIntent>(
-          onInvoke: (_) => onEscapePressed?.call(),
+          onInvoke: (_) => widget.onEscapePressed?.call(),
         ),
       },
       child: NakedTabsScope(
         selectedTabId: _effectiveSelectedTabId,
         onChanged: _selectTab,
-        orientation: orientation,
+        orientation: widget.orientation,
         enabled: _effectiveEnabled,
-        onEscapePressed: onEscapePressed,
-        child: child,
+        onEscapePressed: widget.onEscapePressed,
+        child: widget.child,
       ),
     );
   }
@@ -292,6 +318,10 @@ class NakedTab extends StatefulWidget {
   final ValueWidgetBuilder<NakedTabState>? builder;
 
   /// Semantic label for the trigger.
+  ///
+  /// When provided it replaces the semantics of the tab's content, so a tab
+  /// whose content already renders the same text is announced once. When null
+  /// the content's own semantics are used.
   final String? semanticLabel;
 
   /// Whether the tab is enabled.
@@ -457,6 +487,10 @@ class _NakedTabState extends State<NakedTab>
             selected: isSelected,
             button: true,
             label: widget.semanticLabel,
+            // An explicit label replaces the content's semantics; without this
+            // a tab whose content renders the same text is announced twice.
+            // When no label is given the content's own semantics flow through.
+            excludeSemantics: widget.semanticLabel != null,
             onTap: _isEnabled ? _handleTap : null,
             child: gestureDetector,
           );

--- a/packages/naked_ui/test/semantics/naked_tabs_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tabs_semantics_test.dart
@@ -104,8 +104,17 @@ void main() {
         ),
       );
 
+      // Raw label match: 'Overview\nOverview' would fail here (the summary
+      // below normalizes duplicated lines away, so it cannot catch this).
       final node = tester.getSemantics(find.bySemanticsLabel('Overview'));
       expect(node.label, 'Overview');
+
+      // Replacing the content's semantics must not drop the tab contract.
+      final summary = summarizeMergedFromRoot(tester, control: ControlType.tab);
+      expect(summary.label, 'Overview');
+      expect(summary.flags, containsAll(['isButton', 'isSelected']));
+      expect(summary.flags, containsAll(['hasEnabledState', 'isEnabled']));
+      expect(summary.actions, contains('tap'));
       handle.dispose();
     });
 

--- a/packages/naked_ui/test/semantics/naked_tabs_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_tabs_semantics_test.dart
@@ -75,6 +75,40 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('explicit semanticLabel replaces content semantics', (
+      tester,
+    ) async {
+      // Regression: a tab with semanticLabel whose content renders the same
+      // text was announced twice ("Overview\nOverview").
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NakedTabs(
+              selectedTabId: 'overview',
+              onChanged: (_) {},
+              child: NakedTabBar(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: const [
+                    NakedTab(
+                      tabId: 'overview',
+                      semanticLabel: 'Overview',
+                      child: Text('Overview'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final node = tester.getSemantics(find.bySemanticsLabel('Overview'));
+      expect(node.label, 'Overview');
+      handle.dispose();
+    });
+
     testWidgets('hovered selected tab keeps selected button contract', (
       tester,
     ) async {

--- a/packages/naked_ui/test/src/naked_tabs_test.dart
+++ b/packages/naked_ui/test/src/naked_tabs_test.dart
@@ -195,7 +195,7 @@ void main() {
       // is produced, and a host that rejects the change marks nothing dirty —
       // no frame separates two real key presses, so the second press was
       // swallowed. Deliberately no pump between the two activations below;
-      // pumping would manufacture a frame production never gets.
+      // pumping would manufacture a frame that production never gets.
       final changes = <String>[];
       final tab1 = UniqueKey();
       final tab2 = UniqueKey();
@@ -302,7 +302,7 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pump();
 
-    // The tap selected 'tab1' exactly once; Space re-activates the now
+    // The tap selected 'tab1' exactly once; Space re-activates the
     // already-selected tab, which is a no-op. An exact list guards against
     // a future double-fire.
     expect(changes, ['tab1']);

--- a/packages/naked_ui/test/src/naked_tabs_test.dart
+++ b/packages/naked_ui/test/src/naked_tabs_test.dart
@@ -188,6 +188,71 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Keyboard activation on a rejecting host fires onChanged every press',
+    (tester) async {
+      // Regression: a frame-scoped dedup guard is only cleared when a frame
+      // is produced, and a host that rejects the change marks nothing dirty —
+      // no frame separates two real key presses, so the second press was
+      // swallowed. Deliberately no pump between the two activations below;
+      // pumping would manufacture a frame production never gets.
+      final changes = <String>[];
+      final tab1 = UniqueKey();
+      final tab2 = UniqueKey();
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          builder: (context, child) => child ?? const SizedBox.shrink(),
+          pageRouteBuilder: _defaultPageRouteBuilder,
+          home: Directionality(
+            textDirection: TextDirection.ltr,
+            child: NakedTabs(
+              // Never rebuilt with a new selection: models a host that
+              // rejects every requested change.
+              selectedTabId: 'tab1',
+              onChanged: changes.add,
+              child: Column(
+                children: [
+                  NakedTabBar(
+                    child: Row(
+                      children: [
+                        NakedTab(
+                          key: tab1,
+                          tabId: 'tab1',
+                          child: const Text('Tab 1'),
+                        ),
+                        NakedTab(
+                          key: tab2,
+                          tabId: 'tab2',
+                          child: const Text('Tab 2'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Focus tab1 (selecting the already-selected tab is a no-op), then
+      // traverse to tab2: selection follows focus and fires once.
+      await tester.tap(find.byKey(tab1));
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(changes, ['tab2']);
+
+      // Each activation is a new request, with no frame between them.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      expect(changes, ['tab2', 'tab2', 'tab2']);
+    },
+  );
+
   testWidgets('Selection follows focus via arrow keys', (tester) async {
     final changes = <String>[];
     final tab1 = UniqueKey();
@@ -237,8 +302,10 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pump();
 
-    // Selection is already 'tab1' due to focus; Space keeps it.
-    expect(changes.contains('tab1'), isTrue);
+    // The tap selected 'tab1' exactly once; Space re-activates the now
+    // already-selected tab, which is a no-op. An exact list guards against
+    // a future double-fire.
+    expect(changes, ['tab1']);
   });
 
   testWidgets('Disabled group: selection does not change on focus or tap', (
@@ -882,6 +949,60 @@ void main() {
       // Go back to previous.
       controller.selectPrevious();
       expect(controller.selectedTabId, 'tab1');
+    });
+
+    testWidgets('one press produces exactly one controller notification', (
+      tester,
+    ) async {
+      final controller = NakedTabController(selectedTabId: 'tab1');
+      addTearDown(controller.dispose);
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          builder: (context, child) => child ?? const SizedBox.shrink(),
+          pageRouteBuilder: _defaultPageRouteBuilder,
+          home: Directionality(
+            textDirection: TextDirection.ltr,
+            child: NakedTabs(
+              controller: controller,
+              child: NakedTabBar(
+                child: Row(
+                  children: [
+                    NakedTab(
+                      tabId: 'tab1',
+                      child: const SizedBox(
+                        key: Key('tab1'),
+                        width: 100,
+                        height: 40,
+                      ),
+                    ),
+                    NakedTab(
+                      tabId: 'tab2',
+                      child: const SizedBox(
+                        key: Key('tab2'),
+                        width: 100,
+                        height: 40,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Settle past the tap's focus follow-up: the press must notify once,
+      // not once from the tap and again when focus lands.
+      await tester.tap(find.byKey(const Key('tab2')));
+      await tester.pumpAndSettle();
+
+      expect(notifications, 1);
+      expect(controller.selectedTabId, 'tab2');
     });
 
     testWidgets('selectPrevious does nothing when no previous tab', (

--- a/packages/naked_ui/test/src/naked_tabs_test.dart
+++ b/packages/naked_ui/test/src/naked_tabs_test.dart
@@ -178,6 +178,13 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(changes, ['tab2']);
+
+      // A later user press is a new request, even if the controlled host has
+      // not committed the earlier selection.
+      await tester.tap(find.byKey(tab2));
+      await tester.pumpAndSettle();
+
+      expect(changes, ['tab2', 'tab2']);
     },
   );
 

--- a/packages/naked_ui/test/src/naked_tabs_test.dart
+++ b/packages/naked_ui/test/src/naked_tabs_test.dart
@@ -130,6 +130,57 @@ void main() {
     );
   }
 
+  testWidgets(
+    'Controlled host that commits asynchronously receives one onChanged '
+    'per press',
+    (tester) async {
+      // Regression: focusing a tab selects it (selection follows focus) and
+      // the tap that caused the focus selects it again. A host that does not
+      // rebuild synchronously inside onChanged must still see one call.
+      final changes = <String>[];
+      final tab2 = UniqueKey();
+
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          builder: (context, child) => child ?? const SizedBox.shrink(),
+          pageRouteBuilder: _defaultPageRouteBuilder,
+          home: Directionality(
+            textDirection: TextDirection.ltr,
+            child: NakedTabs(
+              // Never rebuilt with a new selection: models a host that commits
+              // asynchronously (or rejects the change).
+              selectedTabId: 'tab1',
+              onChanged: changes.add,
+              child: Column(
+                children: [
+                  NakedTabBar(
+                    child: Row(
+                      children: [
+                        const NakedTab(tabId: 'tab1', child: Text('Tab 1')),
+                        NakedTab(
+                          key: tab2,
+                          tabId: 'tab2',
+                          child: const Text('Tab 2'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(tab2));
+      await tester.pumpAndSettle();
+
+      expect(changes, ['tab2']);
+    },
+  );
+
   testWidgets('Selection follows focus via arrow keys', (tester) async {
     final changes = <String>[];
     final tab1 = UniqueKey();


### PR DESCRIPTION
## What

Two fixes for `NakedTabs`/`NakedTab`, found while building an adaptive-UI renderer (Muse Remix Studio) on top of Remix.

### 1. Controlled mode fires `onChanged` twice for one press

Pressing a tab focuses it (selection follows focus) and taps it, and both paths call `selectTab`. The existing guard only compares against `selectedTabId`:

```dart
if (!_effectiveEnabled || tabId == _effectiveSelectedTabId) return;
```

With a **controller** this is harmless — `controller.selectTab` updates synchronously, so the second call de-duplicates. With the **controlled** API (`selectedTabId` + `onChanged`), the documented external-state pattern, `selectedTabId` does not move until the host commits, so a host that commits asynchronously receives two `onChanged` calls per press. Downstream impact: one tab press double-dispatched a host action.

**Fix:** the dedup lives in `NakedTab`, where both dispatch paths originate. A press arms a flag when its `requestFocus` will actually produce a focus event, and the very next focus event on that tab consumes it, suppressing only the focus-driven follow-up; `NakedTabs` stays a `StatelessWidget`. Deliberately no frame or timer scoping: a host that rejects the change schedules no frame, so a frame-scoped guard would swallow keyboard Enter/Space retries. Controller and `onChanged` modes behave identically.

### 2. Tab label announced twice

`NakedTab` applied `Semantics(label:)` around content that still contributed its own semantics, so a tab whose content renders the same text was announced as `"Overview\nOverview"`. `NakedAccordion` already excludes trigger content before labelling; `NakedTab` did not.

**Fix:** an explicit `semanticLabel` now sets `excludeSemantics: true` and replaces the content's label. Without one, content semantics flow through unchanged — the Material-parity tests rely on that inheritance, which is why this is conditional rather than the accordion's unconditional exclusion.

## Verification

- Regression tests cover both fixes: two separate pointer presses and two keyboard activations against a controlled host that never commits (each fires exactly once), exactly one controller notification per press, and the `semanticLabel` tab keeping its button/selected/tap semantics with content semantics replaced.
- The keyboard-retry test is proven discriminating: it fails against a frame-scoped guard and passes with this fix.
- Analyzer clean; `dart doc --dry-run` clean.
- Full package suite on this branch: **534 pass, zero failures** (3 external integration cases skipped by default).

## Notes

- Changelog entries added under `## Unreleased`.
- Related (not fixed here): `NakedTab`/`NakedTabView` expose no `SemanticsRole.tab`/`tabPanel`, and the accordion trigger exposes no `expanded` state — every consumer must re-add these. Happy to file separately.
- Related (not fixed here): the `excludeSemantics` doc comment ("the widget and its children are hidden") contradicts the implementation across ~11 components — only the widget's own semantics node is dropped, content semantics still flow. Needs a package-wide decision on which side is the contract.
