### PR TITLE
chore(release): prepare 1.0.0-beta.2

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0
+## 1.0.0-beta.2
 
 ### Breaking changes
 

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/btwld/naked_ui
 documentation: https://docs.page/btwld/naked_ui
 issue_tracker: https://github.com/btwld/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0
+version: 1.0.0-beta.2
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## What

Bumps `packages/naked_ui` from `1.0.0` → **`1.0.0-beta.2`** (prerelease) and renames the top CHANGELOG heading to match.

## Why

The staged `1.0.0` on `main` was never published — pub.dev's latest is `1.0.0-beta.1`. We're shipping this hardening work as **another prerelease** rather than committing to stable 1.0.0 yet.

## Changes

- `pubspec.yaml`: `version: 1.0.0` → `1.0.0-beta.2`
- `CHANGELOG.md`: heading `## 1.0.0` → `## 1.0.0-beta.2`

**Deliberate call:** the existing `## 1.0.0` notes describe exactly the payload shipping in this prerelease, so the heading is renamed (not duplicated). When stable 1.0.0 is cut later, add a fresh `## 1.0.0` entry above this one. Matching the heading to the published version also makes pub.dev's changelog tab anchor correctly.

## Release step (after merge)

This PR does **not** publish. Publishing is triggered by pushing the tag:

```bash
git tag v1.0.0-beta.2   # on merged main
git push origin v1.0.0-beta.2
```

`.github/workflows/release.yml` then publishes `naked_ui 1.0.0-beta.2` to pub.dev via trusted publishing.