### PR TITLE
fix(naked-ui): preserve descendant alert autofocus

### DIFF
--- a/docs/widget/dialog.mdx
+++ b/docs/widget/dialog.mdx
@@ -128,7 +128,7 @@ Future<T?> showNakedAlertDialog<T>({
 ```
 
 - semanticLabel: Required, non-empty, caller-localized alert-dialog name.
-- initialFocusNode: Optional caller-owned safe target. The first traversable descendant is used when it is absent or unusable.
+- initialFocusNode: Optional caller-owned safe target. When it is absent or unusable, descendant autofocus is honored before falling back to the first traversable descendant.
 - barrierDismissible: Outside taps are inert by default. When enabled, `barrierLabel` must be non-empty and localized.
 - Escape and platform Back: Always cancel safely with a null result.
 - Focus always enters the alert, loops inside, and returns to a surviving invoker when the route closes.

--- a/packages/naked_ui/lib/src/naked_dialog.dart
+++ b/packages/naked_ui/lib/src/naked_dialog.dart
@@ -15,10 +15,11 @@ import 'utilities/intents.dart';
 /// action and for testing every supported cancellation path.
 ///
 /// An attached and focusable [initialFocusNode] receives focus after the route
-/// opens. Otherwise the first traversable descendant receives focus. The node
-/// remains owned by the caller and is never disposed by Naked UI. For
-/// irreversible work, prefer the least destructive action; long structured
-/// content may instead use a non-action focus target near its beginning.
+/// opens. Otherwise a descendant autofocus request is honored, falling back to
+/// the first traversable descendant. The node remains owned by the caller and
+/// is never disposed by Naked UI. For irreversible work, prefer the least
+/// destructive action; long structured content may instead use a non-action
+/// focus target near its beginning.
 Future<T?> showNakedAlertDialog<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -136,7 +137,7 @@ class _NakedAlertDialogFocusState extends State<_NakedAlertDialogFocus> {
       if (firstFocus != null &&
           firstFocus != scope &&
           firstFocus.canRequestFocus) {
-        firstFocus.requestFocus();
+        scope.autofocus(firstFocus);
       }
     });
   }

--- a/packages/naked_ui/test/src/naked_dialog_test.dart
+++ b/packages/naked_ui/test/src/naked_dialog_test.dart
@@ -518,6 +518,47 @@ void main() {
       await tester.pump();
     });
 
+    testWidgets('fallback preserves a descendant autofocus request', (
+      tester,
+    ) async {
+      final firstNode = FocusNode(debugLabel: 'first alert action');
+      final autofocusNode = FocusNode(debugLabel: 'autofocus alert action');
+      addTearDown(firstNode.dispose);
+      addTearDown(autofocusNode.dispose);
+      final hostContext = await _pumpEmptyHost(tester);
+
+      showNakedAlertDialog<void>(
+        context: hostContext,
+        barrierColor: Colors.black54,
+        semanticLabel: 'Confirm action',
+        transitionDuration: Duration.zero,
+        builder: (context) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              focusNode: firstNode,
+              onPressed: () {},
+              child: const Text('First'),
+            ),
+            ElevatedButton(
+              autofocus: true,
+              focusNode: autofocusNode,
+              onPressed: () {},
+              child: const Text('Autofocus'),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(FocusManager.instance.primaryFocus, same(autofocusNode));
+
+      Navigator.of(hostContext).pop();
+      await tester.pump();
+      await tester.pump();
+    });
+
     testWidgets('closing after removing the invoker does not throw', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

`showNakedAlertDialog` previously forced focus onto the first traversable descendant when `initialFocusNode` was absent or unusable, overriding an explicit descendant autofocus request. This changes the fallback to `FocusScopeNode.autofocus` so explicit autofocus wins while preserving first-descendant fallback behavior, and adds regression coverage plus updated documentation.

## Related Issues

Closes #69.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.