### PR TITLE
chore(release): prepare 1.0.0-beta.4

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.4
 
 ### Features
 

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/btwld/naked_ui
 documentation: https://docs.page/btwld/naked_ui
 issue_tracker: https://github.com/btwld/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.3
+version: 1.0.0-beta.4
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepare `naked_ui` 1.0.0-beta.4 by promoting the current unreleased changelog entries and bumping the package version.

## Validation

- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test packages/naked_ui/test`
- `flutter test packages/example/test`
- `flutter pub publish --dry-run` (0 warnings)