### PR TITLE
docs: fix component documentation links and API references

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -75,6 +75,8 @@ Components handle behavior. Builders define appearance.
 - NakedDialog - modal dialog behavior + focus trap
 - NakedTooltip - anchored tooltip with lifecycle
 - NakedPopover - anchored, dismissible popover overlay
+- NakedSwitch - on/off control with switch semantics
+- NakedTextField - native text editing with custom styling
 
 ## Getting Started
 
@@ -82,7 +84,7 @@ Components handle behavior. Builders define appearance.
 
 ```yaml
 dependencies:
-  naked_ui: ^latest_version  # https://pub.dev/packages/naked_ui
+  naked_ui: ^1.0.0-beta.4  # https://pub.dev/packages/naked_ui
 ```
 
 Then: `flutter pub get`

--- a/docs/widget/accordion.mdx
+++ b/docs/widget/accordion.mdx
@@ -14,7 +14,7 @@ Headless accordion component. Handles section expansion, keyboard navigation, an
 - **Space-saving layouts**: Show/hide content sections as needed
 
 <Info>
-  A complete example lives in [`example/lib/api/naked_accordion.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_accordion.0.dart).
+  A complete example lives in [`packages/example/lib/api/naked_accordion.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_accordion.0.dart).
 </Info>
 
 ## Basic implementation
@@ -98,7 +98,7 @@ class _AccordionSectionState extends State<_AccordionSection> {
           child: Row(
             children: [
               Expanded(
-                child: const Text(
+                child: Text(
                   widget.title,
                   style: const TextStyle(fontWeight: FontWeight.w600),
                 ),
@@ -123,7 +123,7 @@ class _AccordionSectionState extends State<_AccordionSection> {
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        child: const Text(widget.body),
+        child: Text(widget.body),
       ),
     );
   }
@@ -202,6 +202,7 @@ const NakedAccordion({
   this.onHoverChange,
   this.onPressChange,
   this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -211,6 +212,7 @@ const NakedAccordion({
 - interaction callbacks: `onFocusChange`, `onHoverChange`, `onPressChange`
 - `transitionBuilder` lets you wrap the panel with your own show/hide animation
 - `enabled` / `mouseCursor` / `enableFeedback` provide interaction affordance hooks
+- `excludeSemantics` → hide the accordion header and panel from the semantic tree
 
 ## Accessibility Guidance
 

--- a/docs/widget/button.mdx
+++ b/docs/widget/button.mdx
@@ -14,7 +14,7 @@ Headless button component. Handles click interactions, keyboard navigation, and 
 - **Custom designs**: When standard button styles don't match your design system
 
 <Info>
-  You can find this example in our [GitHub repository](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_button.0.dart).
+  You can find this example in our [GitHub repository](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_button.0.dart).
 </Info>
 ## Basic implementation
 
@@ -170,6 +170,7 @@ const NakedButton({
   this.focusOnPress = false,
   this.tooltip,
   this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -183,6 +184,9 @@ Called when the button is tapped or activated via keyboard. If null, the button 
 
 #### onLongPress → `VoidCallback?`
 Called when the button is long pressed.
+
+#### excludeSemantics → `bool`
+Whether to hide the button and its descendants from accessibility services. Defaults to false.
 
 #### onHoverChange → `ValueChanged<bool>?`
 Called when hover state changes. Provides the current hover state (true when hovered, false otherwise). **Note**: This is legacy - prefer using the `builder` pattern to access `state.isHovered`.

--- a/docs/widget/checkbox.mdx
+++ b/docs/widget/checkbox.mdx
@@ -14,7 +14,7 @@ Headless checkbox component. Handles toggle behavior, keyboard activation, and a
 - **Agreement confirmations**: Terms of service, privacy policies
 
 <Info>
-  See complete examples in our [GitHub repository](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_checkbox.0.dart).
+  See complete examples in our [GitHub repository](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_checkbox.0.dart).
 </Info>
 
 ## Basic implementation
@@ -105,6 +105,7 @@ const NakedCheckbox({
   this.onPressChange,
   this.builder,
   this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -117,6 +118,7 @@ const NakedCheckbox({
 - `child` → static child when you do not need the builder
 - interaction callbacks: `onFocusChange`, `onHoverChange`, `onPressChange`
 - `semanticLabel` → accessible name announced by screen readers
+- `excludeSemantics` → hide the checkbox and its descendants from the semantic tree
 
 ## Accessibility Notes
 

--- a/docs/widget/dialog.mdx
+++ b/docs/widget/dialog.mdx
@@ -15,9 +15,7 @@ Headless dialog component. Handles focus management, backdrop interaction, and a
 - **Custom modals**: When standard dialog styles don't match your design
 
 <Info>
-  Examples: 
-  - Basic: https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_dialog.0.dart
-  - Transitions: https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_dialog.1.dart
+  See the complete example in [`packages/example/lib/api/naked_dialog.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_dialog.0.dart).
 </Info>
 
 ## Basic implementation

--- a/docs/widget/menu.mdx
+++ b/docs/widget/menu.mdx
@@ -14,7 +14,7 @@ Headless menu component. Handles focus, keyboard navigation, outside-click dismi
 - **Custom overlays**: Any triggered overlay that needs menu-like behavior
 
 <Info>
-  Browse the full sample at [`example/lib/api/naked_menu.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_menu.0.dart).
+  Browse the full sample at [`packages/example/lib/api/naked_menu.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_menu.0.dart).
 </Info>
 
 ## Basic implementation
@@ -140,7 +140,7 @@ class _MenuItem extends StatelessWidget {
               Icon(icon, size: 16,
                   color: selected ? Colors.blue : Colors.grey.shade700),
               const SizedBox(width: 12),
-              Expanded(child: const Text(label)),
+              Expanded(child: Text(label)),
               if (selected)
                 const Icon(Icons.check, size: 16, color: Colors.blue),
             ],
@@ -188,6 +188,8 @@ const NakedMenu({
   this.closeOnClickOutside = true,
   this.triggerFocusNode,
   this.positioning = const OverlayPositionConfig(),
+  this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -201,6 +203,8 @@ const NakedMenu({
 - `closeOnClickOutside` → hide the overlay when tapping outside (default `true`)
 - `consumeOutsideTaps` / `useRootOverlay` → capture outside taps before they reach ancestors or target the root overlay stack
 - `triggerFocusNode` → reuse an external focus node so focus returns to the trigger after closing
+- `semanticLabel` → provide an accessible name for the menu trigger
+- `excludeSemantics` → hide the menu trigger and overlay from the semantic tree
 - Lifecycle hooks: `onOpen`, `onClose`, `onCanceled` announce overlay visibility; `onOpenRequested`, `onCloseRequested` let you intercept RawMenuAnchor requests before they commit
 
 ## NakedMenuItem Essentials

--- a/docs/widget/menu.mdx
+++ b/docs/widget/menu.mdx
@@ -204,7 +204,7 @@ const NakedMenu({
 - `consumeOutsideTaps` / `useRootOverlay` → capture outside taps before they reach ancestors or target the root overlay stack
 - `triggerFocusNode` → reuse an external focus node so focus returns to the trigger after closing
 - `semanticLabel` → provide an accessible name for the menu trigger
-- `excludeSemantics` → hide the menu trigger and overlay from the semantic tree
+- `excludeSemantics` → hide the menu trigger subtree from the semantic tree; opened overlay content remains exposed
 - Lifecycle hooks: `onOpen`, `onClose`, `onCanceled` announce overlay visibility; `onOpenRequested`, `onCloseRequested` let you intercept RawMenuAnchor requests before they commit
 
 ## NakedMenuItem Essentials

--- a/docs/widget/popover.mdx
+++ b/docs/widget/popover.mdx
@@ -170,7 +170,7 @@ const NakedPopover({
 - `triggerFocusNode` → provide an external `FocusNode` for restoring focus after close
 - Lifecycle hooks: `onOpen`, `onClose`, `onOpenRequested`, `onCloseRequested`
 - `semanticLabel` → provide an accessible name for the popover trigger
-- `excludeSemantics` → hide the popover trigger and content from the semantic tree
+- `excludeSemantics` → hide the popover trigger subtree from the semantic tree; opened popover content remains exposed
 
 ## Behaviour & Accessibility
 

--- a/docs/widget/popover.mdx
+++ b/docs/widget/popover.mdx
@@ -14,7 +14,7 @@ Headless popover component. Handles positioning, focus management, outside dismi
 - **Content previews**: Preview links, images, or documents
 
 <Info>
-  Explore the sample in [`example/lib/api/naked_popover.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_popover.0.dart).
+  Explore the sample in [`packages/example/lib/api/naked_popover.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_popover.0.dart).
 </Info>
 
 ## Basic implementation
@@ -155,6 +155,8 @@ const NakedPopover({
   this.onOpenRequested,
   this.onCloseRequested,
   this.controller,
+  this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -167,6 +169,8 @@ const NakedPopover({
 - `consumeOutsideTaps` / `useRootOverlay` → control gesture capture and overlay target
 - `triggerFocusNode` → provide an external `FocusNode` for restoring focus after close
 - Lifecycle hooks: `onOpen`, `onClose`, `onOpenRequested`, `onCloseRequested`
+- `semanticLabel` → provide an accessible name for the popover trigger
+- `excludeSemantics` → hide the popover trigger and content from the semantic tree
 
 ## Behaviour & Accessibility
 

--- a/docs/widget/radio.mdx
+++ b/docs/widget/radio.mdx
@@ -14,7 +14,7 @@ Headless radio button component. RadioGroup coordinates keyboard navigation and 
 - **Filters**: Select one filter option from a category
 
 <Info>
-  Full examples are available in [`example/lib/api/naked_radio.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_radio.0.dart).
+  Full examples are available in [`packages/example/lib/api/naked_radio.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_radio.0.dart).
 </Info>
 
 ## Basic implementation
@@ -153,6 +153,8 @@ const NakedRadio<T>({
   this.onPressChange,
   this.builder,
   this.groupRegistry,
+  this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -163,6 +165,8 @@ Key notes:
 - `toggleable` lets the selected radio clear the group when activated again
 - Pass `focusNode` to integrate with external focus management
 - interaction callbacks: `onPressChange`/`onHoverChange`/`onFocusChange` (prefer `builder` pattern)
+- `semanticLabel` → override the accessible name for the radio
+- `excludeSemantics` → hide the radio and its descendants from the semantic tree
 
 ## Accessibility Tips
 

--- a/docs/widget/select.mdx
+++ b/docs/widget/select.mdx
@@ -183,7 +183,7 @@ const NakedSelect({
 - `mouseCursor` → set the trigger cursor when the select is enabled
 - `triggerFocusNode` → reuse an external focus node; focus is restored here automatically on close
 - `semanticLabel` → override trigger semantics; the current `value?.toString()` is announced when provided
-- `excludeSemantics` → hide the select trigger and overlay from the semantic tree
+- `excludeSemantics` → hide the select trigger subtree from the semantic tree; opened overlay content remains exposed
 - Lifecycle hooks: `onOpen`, `onClose`, `onCanceled` fire around overlay visibility; `onOpenRequested`, `onCloseRequested` intercept RawMenuAnchor requests (e.g. for animations)
 
 ## Options via `NakedSelect.Option`

--- a/docs/widget/select.mdx
+++ b/docs/widget/select.mdx
@@ -14,7 +14,7 @@ Headless select dropdown component. Handles keyboard navigation, focus managemen
 - **Data selection**: Pick items from large sets with search/grouping
 
 <Info>
-  Working samples are in [`example/lib/api/naked_select.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_select.0.dart) (plus `.1`/`.2` for searchable and grouped variants).
+  Working samples are in [`packages/example/lib/api/naked_select.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_select.0.dart) (plus `.1`/`.2` for searchable and grouped variants).
 </Info>
 
 ## Basic implementation
@@ -153,6 +153,7 @@ const NakedSelect({
   this.closeOnSelect = true,
   this.closeOnClickOutside = true,
   this.enabled = true,
+  this.mouseCursor = SystemMouseCursors.click,
   this.triggerFocusNode,
   this.semanticLabel,
   this.positioning = const OverlayPositionConfig(
@@ -166,6 +167,7 @@ const NakedSelect({
   this.onCloseRequested,
   this.consumeOutsideTaps = true,
   this.useRootOverlay = false,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -178,8 +180,10 @@ const NakedSelect({
 - `closeOnSelect` / `closeOnClickOutside` → opt into dismissal after selection and pointer taps outside
 - `consumeOutsideTaps` / `useRootOverlay` → control how outside gestures are captured and which overlay stack is used
 - `enabled` → disables trigger & option activation when false
+- `mouseCursor` → set the trigger cursor when the select is enabled
 - `triggerFocusNode` → reuse an external focus node; focus is restored here automatically on close
 - `semanticLabel` → override trigger semantics; the current `value?.toString()` is announced when provided
+- `excludeSemantics` → hide the select trigger and overlay from the semantic tree
 - Lifecycle hooks: `onOpen`, `onClose`, `onCanceled` fire around overlay visibility; `onOpenRequested`, `onCloseRequested` intercept RawMenuAnchor requests (e.g. for animations)
 
 ## Options via `NakedSelect.Option`

--- a/docs/widget/slider.mdx
+++ b/docs/widget/slider.mdx
@@ -14,7 +14,7 @@ Headless slider component. Handles drag interactions, keyboard navigation (arrow
 - **Custom designs**: When you need sliders that match your design system perfectly
 
 <Info>
-  See complete examples in our [GitHub repository](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_slider.0.dart).
+  See complete examples in our [GitHub repository](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_slider.0.dart).
 </Info>
 ## Basic implementation
 
@@ -169,7 +169,7 @@ NakedSlider(
 
 ### Custom painters (advanced)
 
-For complex designs, you can use CustomPaint for pixel-perfect control. Check out our [complete CustomPaint examples](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_slider.0.dart) in the repository.
+For complex designs, you can use CustomPaint for pixel-perfect control. Check out our [complete CustomPaint examples](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_slider.0.dart) in the repository.
 
 
 ## Constructor
@@ -198,6 +198,8 @@ const NakedSlider({
   this.keyboardStep = 0.01,
   this.largeKeyboardStep = 0.1,
   this.semanticLabel,
+  this.semanticFormatterCallback,
+  this.excludeSemantics = false,
 })
 ```
 

--- a/docs/widget/switch.mdx
+++ b/docs/widget/switch.mdx
@@ -14,7 +14,7 @@ Headless switch component. Handles toggle behavior and accessibility with switch
 - **Status controls**: Active/inactive, enabled/disabled states
 
 <Info>
-  See the runnable sample in [`example/lib/api/naked_toggle.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_toggle.0.dart) under the "Switch" section.
+  See the runnable sample in [`packages/example/lib/api/naked_toggle.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_toggle.0.dart) under the "Switch" section.
 </Info>
 
 ## Basic implementation

--- a/docs/widget/tabs.mdx
+++ b/docs/widget/tabs.mdx
@@ -20,7 +20,7 @@ Headless tabs component. Handles keyboard navigation (arrow keys) and selection 
 - `NakedTabView` – panel that shows/hides content based on the active tab
 
 <Info>
-  See the complete implementation in [`example/lib/api/naked_tabs.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_tabs.0.dart).
+  See the complete implementation in [`packages/example/lib/api/naked_tabs.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_tabs.0.dart).
 </Info>
 
 ## Basic implementation
@@ -128,7 +128,7 @@ class _TabChip extends StatelessWidget {
               width: isFocused ? 2 : 1,
             ),
           ),
-          child: const Text(
+          child: Text(
             label,
             style: TextStyle(
               fontWeight: FontWeight.w600,
@@ -159,7 +159,7 @@ class _PanelBox extends StatelessWidget {
         color: color,
         borderRadius: BorderRadius.circular(12),
       ),
-      child: const Text(text),
+      child: Text(text),
     );
   }
 }
@@ -218,12 +218,14 @@ const NakedTab({
   this.onPressChange,
   this.builder,
   this.semanticLabel,
+  this.excludeSemantics = false,
 })
 ```
 
 - Provide either `child` or `builder`
 - `builder` → `ValueWidgetBuilder<NakedTabState>?`
 - `semanticLabel` → override accessible name
+- `excludeSemantics` → hide the tab and its descendants from the semantic tree
 - interaction callbacks: `onFocusChange`, `onHoverChange`, `onPressChange`
 
 ### NakedTabView

--- a/docs/widget/textfield.mdx
+++ b/docs/widget/textfield.mdx
@@ -14,7 +14,7 @@ Headless text input component. Preserves native text editing behavior (selection
 - **Specialized inputs**: Custom styled inputs that standard TextFields can't provide
 
 <Info>
-  See the complete example in [`example/lib/api/naked_textfield.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_textfield.0.dart).
+  See the complete example in [`packages/example/lib/api/naked_textfield.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_textfield.0.dart).
 </Info>
 
 ## Basic implementation
@@ -128,6 +128,7 @@ const NakedTextField({
   this.onAppPrivateCommand,
   this.inputFormatters,
   this.enabled = true,
+  this.error = false,
   this.cursorWidth = 2.0,
   this.cursorHeight,
   this.cursorRadius,
@@ -165,7 +166,9 @@ const NakedTextField({
   this.ignorePointers,
   this.semanticLabel,
   this.semanticHint,
+  this.semanticErrorText,
   this.strutStyle,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -185,7 +188,8 @@ const NakedTextField({
 
 ## Accessibility & Semantics
 
-- Supply `semanticLabel` / `semanticHint` when the visual chrome lacks textual context
+- Supply `semanticLabel`, `semanticHint`, and `semanticErrorText` when the visual chrome lacks textual context
+- Set `excludeSemantics` to hide the field and its descendants from accessibility services
 - `NakedTextField` wraps the builder result with proper `Semantics` for focusable text fields
 - Respect contrast and focus indicators in your builder to ensure the field remains discoverable
 

--- a/docs/widget/textfield.mdx
+++ b/docs/widget/textfield.mdx
@@ -188,10 +188,23 @@ const NakedTextField({
 
 ## Accessibility & Semantics
 
-- Supply `semanticLabel`, `semanticHint`, and `semanticErrorText` when the visual chrome lacks textual context
+- Supply `semanticLabel` and `semanticHint` when the visual chrome lacks textual context
+- Pair `semanticErrorText` with `error: true`; when `error` is false, the error text is not announced and the field is not a live region
 - Set `excludeSemantics` to hide the field and its descendants from accessibility services
 - `NakedTextField` wraps the builder result with proper `Semantics` for focusable text fields
 - Respect contrast and focus indicators in your builder to ensure the field remains discoverable
+
+For a validation error, derive both parameters from the same state:
+
+```dart
+NakedTextField(
+  controller: emailController,
+  error: emailError != null,
+  semanticLabel: 'Email',
+  semanticErrorText: emailError,
+  builder: (context, state, editableText) => editableText,
+);
+```
 
 ## Tips
 

--- a/docs/widget/toggle.mdx
+++ b/docs/widget/toggle.mdx
@@ -172,6 +172,7 @@ const NakedToggle({
   this.builder,
   this.semanticLabel,
   this.asSwitch = false,
+  this.excludeSemantics = false,
 })
 ```
 
@@ -188,6 +189,7 @@ const NakedToggle({
 - `focusNode`, `autofocus`: focus management options
 - interaction callbacks: `onFocusChange`, `onHoverChange`, `onPressChange`
 - `semanticLabel` → `String?`: accessibility label, especially important when no text label is visible
+- `excludeSemantics` → `bool`: hide the toggle and its descendants from the semantic tree
 
 ## Single-select Toggle Group Compatibility
 

--- a/docs/widget/tooltip.mdx
+++ b/docs/widget/tooltip.mdx
@@ -14,7 +14,7 @@ Headless tooltip component built on Flutter's `RawTooltip`. Handles hover/touch 
 - **Feature descriptions**: Brief explanations of complex features
 
 <Info>
-  Working example: [`example/lib/api/naked_tooltip.0.dart`](https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_tooltip.0.dart).
+  Working example: [`packages/example/lib/api/naked_tooltip.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_tooltip.0.dart).
 </Info>
 
 ## Basic implementation


### PR DESCRIPTION
## Description

Fixes stale example links, invalid copy-paste snippets, and incomplete component API references across the documentation. It also pins the install example to 1.0.0-beta.4 and adds NakedSwitch and NakedTextField to the component overview so users see accurate examples and current constructor options. Validated with the pinned Flutter analyzer, the Naked UI and example test suites, and targeted documentation checks.

## Related Issues

None.

---

## Checklist

**Note**: Updating the pubspec.yaml and CHANGELOG.md is not required. These are handled automatically during the release process.

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with ///).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
