### PR TITLE
chore(release): prepare 1.0.0-beta.6

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.0.0-beta.6
+
+### Fixes
+
+- Make `NakedTextField` honor ambient `DefaultSelectionStyle` cursor and
+  selection colors, including context-resolved `CupertinoDynamicColor`
+  variants, while preserving explicit cursor precedence, focus gating, and
+  platform fallbacks.
+
+### Maintenance
+
+- Point package metadata at the canonical `conceptadev/naked_ui` repository.
+
 ## 1.0.0-beta.5
 
 ### Breaking changes

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -1,10 +1,10 @@
 name: naked_ui
 description: A library of behavior-first UI components for Flutter that separate state from presentation.
-repository: https://github.com/btwld/naked_ui
-documentation: https://docs.page/btwld/naked_ui
-issue_tracker: https://github.com/btwld/naked_ui/issues
+repository: https://github.com/conceptadev/naked_ui
+documentation: https://docs.page/conceptadev/naked_ui
+issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.5
+version: 1.0.0-beta.6
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepare `naked_ui` 1.0.0-beta.6 for publication after the `NakedTextField`
selection-color fix merged in #77. This bumps the package version, adds a
curated changelog entry, and updates package metadata to the canonical
`conceptadev/naked_ui` repository.

The release tag must be created only after pub.dev automated publishing is
updated from `btwld/naked_ui` to `conceptadev/naked_ui`; the beta.5 publish run
failed because its OIDC repository did not match the configured repository.

## Related Issues

None.

---

## Checklist

- [x] Existing test coverage for the released fix is already on `main`; this
      PR changes release metadata only.
- [x] The changelog and package metadata are updated; no API documentation
      changes are required.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Validation

- `flutter analyze` — passed with no issues.
- `flutter test` — all 662 tests passed; 3 external integration tests were
  intentionally skipped by default.
- `flutter pub publish --dry-run` — passed with 0 warnings.
