### PR TITLE
feat(slider): add NakedSliderState.visualPercentageOf

### DIFF
--- a/packages/naked_ui/lib/src/naked_slider.dart
+++ b/packages/naked_ui/lib/src/naked_slider.dart
@@ -85,11 +85,15 @@ class NakedSliderState extends NakedState {
     List<double>.generate(values.length, percentageAt),
   );
 
-  /// The physical alignment along [orientation] for the thumb at [index].
+  /// The physical alignment along [orientation] for a logical [percentage].
   ///
-  /// The result is zero at the left/top edge and one at the right/bottom edge.
-  double visualPercentageAt(int index) {
-    var result = percentageAt(index);
+  /// [percentage] is a logical fraction where zero is [min] and one is [max].
+  /// The result is zero at the left/top edge and one at the right/bottom edge,
+  /// accounting for [orientation], [textDirection], and [inverted]. Use this for
+  /// track decorations that are not tied to a thumb, such as the origin of a
+  /// range fill, where [visualPercentageAt] (keyed by thumb index) does not fit.
+  double visualPercentageOf(double percentage) {
+    var result = percentage;
     if (orientation == Axis.horizontal && textDirection == TextDirection.rtl) {
       result = 1 - result;
     } else if (orientation == Axis.vertical) {
@@ -99,6 +103,12 @@ class NakedSliderState extends NakedState {
 
     return result;
   }
+
+  /// The physical alignment along [orientation] for the thumb at [index].
+  ///
+  /// The result is zero at the left/top edge and one at the right/bottom edge.
+  double visualPercentageAt(int index) =>
+      visualPercentageOf(percentageAt(index));
 
   @override
   bool operator ==(Object other) {

--- a/packages/naked_ui/test/src/naked_slider_test.dart
+++ b/packages/naked_ui/test/src/naked_slider_test.dart
@@ -214,6 +214,60 @@ void main() {
       expect(first.hashCode, equal.hashCode);
       expect(first, isNot(different));
     });
+
+    test(
+      'visualPercentageOf flips for direction, orientation, and inversion',
+      () {
+        NakedSliderState create({
+          Axis orientation = Axis.horizontal,
+          TextDirection textDirection = TextDirection.ltr,
+          bool inverted = false,
+        }) => NakedSliderState(
+          states: const <WidgetState>{},
+          values: const [50],
+          min: 0,
+          max: 100,
+          step: 1,
+          minSpacing: 0,
+          orientation: orientation,
+          inverted: inverted,
+          textDirection: textDirection,
+          isDragging: false,
+        );
+
+        // Left-to-right horizontal maps the logical fraction straight through.
+        expect(create().visualPercentageOf(0), 0);
+        expect(create().visualPercentageOf(0.25), 0.25);
+        expect(create().visualPercentageOf(1), 1);
+
+        // Each of RTL, vertical, and inversion mirrors the fraction once.
+        expect(
+          create(textDirection: TextDirection.rtl).visualPercentageOf(0.25),
+          0.75,
+        );
+        expect(
+          create(orientation: Axis.vertical).visualPercentageOf(0.25),
+          0.75,
+        );
+        expect(create(inverted: true).visualPercentageOf(0.25), 0.75);
+
+        // Two mirrors cancel out (RTL combined with inversion).
+        expect(
+          create(
+            textDirection: TextDirection.rtl,
+            inverted: true,
+          ).visualPercentageOf(0.25),
+          0.25,
+        );
+
+        // visualPercentageAt stays consistent with the delegated helper.
+        final state = create(inverted: true);
+        expect(
+          state.visualPercentageAt(0),
+          state.visualPercentageOf(state.percentageAt(0)),
+        );
+      },
+    );
   });
 
   group('pointer behavior', () {


### PR DESCRIPTION
## What

Adds `NakedSliderState.visualPercentageOf(double percentage)` — maps a logical fraction (`0` = `min`, `1` = `max`) to its physical alignment along the track (`0` = left/top edge, `1` = right/bottom edge), accounting for `orientation`, `textDirection`, and `inverted`.

`visualPercentageAt(int index)` now delegates to it. Its behavior is unchanged.

## Why

`visualPercentageAt` is keyed by a **thumb index**, so a consumer that needs the visual position of a point *not* tied to a thumb — for example the origin of a single-thumb range fill — has no way to ask for it and must reimplement the RTL/vertical/inverted flip chain itself. This lifts that logic onto the state that already owns `orientation`/`textDirection`/`inverted`, so downstream code can call it instead of duplicating it.

## Changes

- `NakedSliderState.visualPercentageOf` — new public method
- `visualPercentageAt` delegates to it (no behavior change)
- Unit test covering LTR / RTL / vertical / inverted and the `visualPercentageAt` delegation invariant

## Verification

- `dart format` clean, `dart analyze` clean
- All slider tests pass (`test/src/naked_slider_test.dart`)

Purely additive and backward compatible.