### PR TITLE
chore(release): prepare 1.0.0-beta.7

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0-beta.7
+
+### Features
+
+- Add `NakedSliderState.visualPercentageOf` for mapping arbitrary logical
+  fractions to physical track alignment across orientation, text direction,
+  and inversion, while preserving `visualPercentageAt` thumb placement.
+
 ## 1.0.0-beta.6
 
 ### Fixes

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.6
+version: 1.0.0-beta.7
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepare `naked_ui` 1.0.0-beta.7 for publication after the slider visual-percentage API merged in #79. This bumps the package version and adds a curated changelog entry for `NakedSliderState.visualPercentageOf`.

After this PR is merged and every check is green, the exact squash-merge commit will receive the lightweight tag `v1.0.0-beta.7`. Pushing that tag triggers the Android and web release gates followed by OIDC publication to pub.dev.

## Related Issues

- Includes #79.

---

## Checklist

- [x] Existing tests for the released API are already on `main`; this PR changes release metadata only.
- [x] The changelog and package version are updated.
- [x] The release archive passes `flutter pub publish --dry-run` with zero warnings.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Validation

- `fvm dart run melos ci` — formatting clean, analysis clean, all tests passed across both packages.
- `fvm flutter pub publish --dry-run` — passed with 0 warnings.