### PR TITLE
chore(release): prepare 1.0.0-beta.8

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-beta.8
+
+### Fixes
+
+- Preserve tooltip overlay semantics when `semanticLabel` is absent or blank,
+  while continuing to avoid duplicate announcements when a non-empty label
+  represents the content on the trigger. Explicit semantics overrides remain
+  authoritative.
+
 ## 1.0.0-beta.7
 
 ### Features

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.7
+version: 1.0.0-beta.8
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepare `naked_ui` 1.0.0-beta.8 for publication after the tooltip semantics fix
merged in #82. This bumps the package version and adds a curated changelog entry
for the corrected labeled and unlabeled tooltip behavior.

After this PR is merged and every check is green, the exact squash-merge commit
will receive the lightweight tag `v1.0.0-beta.8`. Pushing that tag triggers the
Android and web release gates followed by OIDC publication to pub.dev.

## Related Issues

- Includes #82.

---

## Checklist

- [x] Behavioral regression tests and documentation were merged in #82; this
      PR changes release metadata only.
- [x] The changelog and package version are updated.
- [x] The release archive passes `flutter pub publish --dry-run` with zero
      warnings.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Validation

- `fvm dart run melos ci` — formatting clean, analysis clean, and all tests
  passed across both packages.
- `fvm flutter pub publish --dry-run` — passed with 0 warnings.
