### PR TITLE
fix(naked-ui): correct selection semantics and press state

### DIFF
--- a/packages/naked_ui/lib/src/naked_textfield.dart
+++ b/packages/naked_ui/lib/src/naked_textfield.dart
@@ -500,10 +500,32 @@ class _NakedTextFieldState extends State<NakedTextField>
     updateFocusState(focused, widget.onFocusChange);
   }
 
+  var _pressEpoch = 0;
+
   void _handlePressChange(bool pressed) {
+    if (isPressed == pressed) return;
+    _pressEpoch++;
     updatePressState(pressed, (value) {
       widget.onTapChange?.call(value);
       widget.onPressChange?.call(value);
+    });
+  }
+
+  void _handlePressReset() {
+    if (!isPressed) return;
+    final epoch = ++_pressEpoch;
+    updatePressState(false, null);
+
+    final tapCallback = widget.onTapChange;
+    final pressCallback = widget.onPressChange;
+    if (tapCallback == null && pressCallback == null) return;
+
+    // Tap tracking also resets when its recognizer is disposed during teardown.
+    // Defer consumer callbacks so rebuilds are safe and skip them after unmount.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _pressEpoch != epoch || isPressed) return;
+      tapCallback?.call(false);
+      pressCallback?.call(false);
     });
   }
 
@@ -977,7 +999,7 @@ class _NakedSelectionGestureDetectorBuilder
   void onTapTrackReset() {
     super.onTapTrackReset();
     if (!_state.widget.enabled) return;
-    _state._handlePressChange(false);
+    _state._handlePressReset();
   }
 
   @override

--- a/packages/naked_ui/lib/src/naked_textfield.dart
+++ b/packages/naked_ui/lib/src/naked_textfield.dart
@@ -501,7 +501,29 @@ class _NakedTextFieldState extends State<NakedTextField>
   }
 
   void _handlePressChange(bool pressed) {
-    updatePressState(pressed, widget.onPressChange);
+    updatePressState(pressed, (value) {
+      widget.onTapChange?.call(value);
+      widget.onPressChange?.call(value);
+    });
+  }
+
+  var _enabledEpoch = 0;
+
+  void _handleEnabledChange(NakedTextField oldWidget) {
+    if (oldWidget.enabled == widget.enabled) return;
+    final epoch = ++_enabledEpoch;
+    if (widget.enabled || !updatePressState(false, null)) return;
+
+    final tapCallback = widget.onTapChange;
+    final pressCallback = widget.onPressChange;
+    if (tapCallback == null && pressCallback == null) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _enabledEpoch == epoch && !widget.enabled && isDisabled) {
+        tapCallback?.call(false);
+        pressCallback?.call(false);
+      }
+    });
   }
 
   bool _shouldShowSelectionHandles(SelectionChangedCause? cause) {
@@ -589,6 +611,7 @@ class _NakedTextFieldState extends State<NakedTextField>
 
     updateDisabledState(!widget.enabled);
     updateErrorState(widget.error);
+    _handleEnabledChange(oldWidget);
 
     if (widget.controller == null && oldWidget.controller != null) {
       _createLocalController(oldWidget.controller!.value);
@@ -662,7 +685,8 @@ class _NakedTextFieldState extends State<NakedTextField>
   late bool forcePressEnabled;
 
   @override
-  bool get selectionEnabled => widget.enableInteractiveSelection;
+  bool get selectionEnabled =>
+      widget.enabled && widget.enableInteractiveSelection;
 
   EditableTextState? get _editableText => editableTextKey.currentState;
 
@@ -944,17 +968,55 @@ class _NakedSelectionGestureDetectorBuilder
 
   @override
   void onTapDown(TapDragDownDetails details) {
-    super.onTapDown(details);
     if (!_state.widget.enabled) return;
-    _state.widget.onTapChange?.call(true);
+    super.onTapDown(details);
     _state._handlePressChange(true);
   }
 
   @override
-  void onSingleTapUp(TapDragUpDetails details) {
-    super.onSingleTapUp(details);
+  void onTapTrackReset() {
+    super.onTapTrackReset();
     if (!_state.widget.enabled) return;
-    _state.widget.onTapChange?.call(false);
+    _state._handlePressChange(false);
+  }
+
+  @override
+  void onForcePressStart(ForcePressDetails details) {
+    if (!_state.widget.enabled) return;
+    super.onForcePressStart(details);
+  }
+
+  @override
+  void onForcePressEnd(ForcePressDetails details) {
+    if (!_state.widget.enabled) return;
+    super.onForcePressEnd(details);
+  }
+
+  @override
+  void onDoubleTapDown(TapDragDownDetails details) {
+    if (!_state.widget.enabled) return;
+    super.onDoubleTapDown(details);
+    _state._handlePressChange(false);
+  }
+
+  @override
+  void onTripleTapDown(TapDragDownDetails details) {
+    if (!_state.widget.enabled) return;
+    super.onTripleTapDown(details);
+    _state._handlePressChange(false);
+  }
+
+  @override
+  void onDragSelectionStart(TapDragStartDetails details) {
+    if (!_state.widget.enabled) return;
+    super.onDragSelectionStart(details);
+    _state._handlePressChange(false);
+  }
+
+  @override
+  void onSingleTapUp(TapDragUpDetails details) {
+    if (!_state.widget.enabled) return;
+    super.onSingleTapUp(details);
     _state._handlePressChange(false);
   }
 
@@ -962,7 +1024,6 @@ class _NakedSelectionGestureDetectorBuilder
   void onSingleTapCancel() {
     super.onSingleTapCancel();
     if (!_state.widget.enabled) return;
-    _state.widget.onTapChange?.call(false);
     _state._handlePressChange(false);
   }
 

--- a/packages/naked_ui/lib/src/naked_toggle.dart
+++ b/packages/naked_ui/lib/src/naked_toggle.dart
@@ -1095,6 +1095,7 @@ class _NakedToggleOptionState<T> extends State<NakedToggleOption<T>>
             enabled: isEnabled,
             selected: isSelected,
             button: true,
+            inMutuallyExclusiveGroup: true,
             label: widget.semanticLabel,
             onTap: isEnabled ? () => _activate(scope) : null,
             child: gestureDetector,

--- a/packages/naked_ui/test/semantics/naked_toggle_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_toggle_semantics_test.dart
@@ -316,7 +316,7 @@ void main() {
           final summary = summarizeNode(option);
           expect(summary.flags, isNot(contains('hasToggledState')));
           expect(summary.flags, isNot(contains('hasCheckedState')));
-          expect(summary.flags, isNot(contains('isInMutuallyExclusiveGroup')));
+          expect(summary.flags, contains('isInMutuallyExclusiveGroup'));
         }
 
         handle.dispose();
@@ -356,6 +356,7 @@ void main() {
         )!;
         final data = italic.getSemanticsData();
         expect(data.flagsCollection.isButton, isTrue);
+        expect(data.flagsCollection.isInMutuallyExclusiveGroup, isTrue);
         expect(data.flagsCollection.isEnabled, Tristate.isFalse);
         expect(data.hasAction(SemanticsAction.tap), isFalse);
 

--- a/packages/naked_ui/test/src/naked_textfield_press_state_test.dart
+++ b/packages/naked_ui/test/src/naked_textfield_press_state_test.dart
@@ -1,0 +1,408 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+Future<void> _pumpField(
+  WidgetTester tester, {
+  required TextEditingController controller,
+  required _PressChanges changes,
+  int? minLines,
+  int? maxLines = 1,
+  ScrollController? scrollController,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 320,
+            child: NakedTextField(
+              controller: controller,
+              minLines: minLines,
+              maxLines: maxLines,
+              scrollController: scrollController,
+              onTapChange: changes.tap.add,
+              onPressChange: changes.aggregate.add,
+              builder: (context, state, editable) => editable,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+class _PressChanges {
+  final tap = <bool>[];
+  final aggregate = <bool>[];
+
+  void expectBoth(List<bool> expected) {
+    expect(tap, expected);
+    expect(aggregate, expected);
+  }
+}
+
+void main() {
+  testWidgets(
+    'double tap releases press when word selection takes ownership',
+    (tester) async {
+      final controller = TextEditingController(text: 'Select this word');
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+
+      await _pumpField(tester, controller: controller, changes: changes);
+
+      final editable = find.byType(EditableText);
+      await tester.tap(editable);
+      await tester.pump(const Duration(milliseconds: 20));
+      await tester.tap(editable);
+      await tester.pump();
+
+      expect(controller.selection.isCollapsed, isFalse);
+      changes.expectBoth([true, false, true, false]);
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.macOS}),
+  );
+
+  testWidgets(
+    'triple tap releases press when paragraph selection owns the gesture',
+    (tester) async {
+      final controller = TextEditingController(text: 'Select this paragraph');
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+
+      await _pumpField(tester, controller: controller, changes: changes);
+
+      final editable = find.byType(EditableText);
+      for (var index = 0; index < 3; index++) {
+        await tester.tap(editable);
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 21),
+      );
+      changes.expectBoth([true, false, true, false, true, false]);
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.macOS}),
+  );
+
+  testWidgets(
+    'long press releases press when long-press selection owns the gesture',
+    (tester) async {
+      final controller = TextEditingController(text: 'Select this word');
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+
+      await _pumpField(tester, controller: controller, changes: changes);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(EditableText)),
+        kind: PointerDeviceKind.touch,
+      );
+      await tester.pump(kPressTimeout);
+      changes.expectBoth([true]);
+
+      await tester.pump(kLongPressTimeout);
+      changes.expectBoth([true, false]);
+
+      await gesture.up();
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.iOS}),
+  );
+
+  testWidgets(
+    'force press releases press when force selection owns the gesture',
+    (tester) async {
+      final controller = TextEditingController(text: 'Select this word');
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+
+      await _pumpField(tester, controller: controller, changes: changes);
+
+      final position = tester.getCenter(find.byType(EditableText));
+      final pointer = tester.nextPointer;
+      final gesture = await tester.createGesture();
+      await gesture.downWithCustomEvent(
+        position,
+        PointerDownEvent(
+          pointer: pointer,
+          position: position,
+          pressure: 0,
+          pressureMin: 0,
+          pressureMax: 6,
+        ),
+      );
+      await tester.pump(kPressTimeout);
+      changes.expectBoth([true]);
+
+      await gesture.updateWithCustomEvent(
+        PointerMoveEvent(
+          pointer: pointer,
+          position: position,
+          pressure: 0.5,
+          pressureMin: 0,
+        ),
+      );
+      await tester.pump();
+
+      expect(controller.selection.isCollapsed, isFalse);
+      changes.expectBoth([true, false]);
+
+      await gesture.up();
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.iOS}),
+  );
+
+  testWidgets(
+    'mouse selection drag releases press when selection owns the gesture',
+    (tester) async {
+      final controller = TextEditingController(
+        text: 'Drag across this editable text to select it',
+      );
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+
+      await _pumpField(tester, controller: controller, changes: changes);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(EditableText)),
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump(kPressTimeout);
+      changes.expectBoth([true]);
+
+      await gesture.moveBy(const Offset(50, 0));
+      await tester.pump(const Duration(milliseconds: 16));
+      await gesture.moveBy(const Offset(50, 0));
+      await tester.pump();
+
+      expect(controller.selection.isCollapsed, isFalse);
+      changes.expectBoth([true, false]);
+
+      await gesture.up();
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.macOS}),
+  );
+
+  testWidgets(
+    'multiline touch scroll releases press when scrolling owns the gesture',
+    (tester) async {
+      final controller = TextEditingController(
+        text: List.generate(12, (index) => 'Line $index').join('\n'),
+      );
+      final scrollController = ScrollController();
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+      addTearDown(scrollController.dispose);
+
+      await _pumpField(
+        tester,
+        controller: controller,
+        minLines: 2,
+        maxLines: 2,
+        scrollController: scrollController,
+        changes: changes,
+      );
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(EditableText)),
+        kind: PointerDeviceKind.touch,
+      );
+      await tester.pump(kPressTimeout);
+      changes.expectBoth([true]);
+
+      await gesture.moveBy(const Offset(0, -40));
+      await tester.pump(const Duration(milliseconds: 16));
+      await gesture.moveBy(const Offset(0, -40));
+      await tester.pump();
+
+      expect(scrollController.offset, greaterThan(0));
+      changes.expectBoth([true, false]);
+
+      await gesture.up();
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.android}),
+  );
+
+  testWidgets('disabling during a press clears both pressed callbacks', (
+    tester,
+  ) async {
+    final controller = TextEditingController(text: 'Disable while pressed');
+    final changes = _PressChanges();
+    var enabled = true;
+    var states = <WidgetState>{};
+    var callbackRebuilds = 0;
+    late StateSetter setHostState;
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            setHostState = setState;
+            return NakedTextField(
+              controller: controller,
+              enabled: enabled,
+              onTapChange: changes.tap.add,
+              onPressChange: (pressed) {
+                changes.aggregate.add(pressed);
+                if (!pressed) {
+                  setHostState(() => callbackRebuilds++);
+                }
+              },
+              builder: (context, state, editable) {
+                states = state.states;
+                return editable;
+              },
+            );
+          },
+        ),
+      ),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(EditableText)),
+    );
+    await tester.pump(kPressTimeout);
+    changes.expectBoth([true]);
+    expect(states, contains(WidgetState.pressed));
+
+    setHostState(() => enabled = false);
+    await tester.pump();
+    changes.expectBoth([true, false]);
+    expect(callbackRebuilds, 1);
+    expect(states, contains(WidgetState.disabled));
+    expect(states, isNot(contains(WidgetState.pressed)));
+
+    await tester.pump();
+
+    await gesture.up();
+    await tester.pump();
+    changes.expectBoth([true, false]);
+
+    setHostState(() => enabled = true);
+    await tester.pump();
+    changes.expectBoth([true, false]);
+    expect(states, isNot(contains(WidgetState.disabled)));
+    expect(states, isNot(contains(WidgetState.pressed)));
+  });
+
+  testWidgets(
+    'disabled pointer gestures do not select or focus the field',
+    (tester) async {
+      final controller = TextEditingController.fromValue(
+        const TextEditingValue(
+          text: 'Disabled field text',
+          selection: TextSelection.collapsed(offset: 0),
+        ),
+      );
+      final focusNode = FocusNode();
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(
+              navigationMode: NavigationMode.directional,
+            ),
+            child: NakedTextField(
+              controller: controller,
+              focusNode: focusNode,
+              enabled: false,
+              onTapChange: changes.tap.add,
+              onPressChange: changes.aggregate.add,
+              builder: (context, state, editable) => editable,
+            ),
+          ),
+        ),
+      );
+
+      final editable = find.byType(EditableText);
+      final position = tester.getCenter(editable);
+      await tester.tapAt(position);
+      await tester.pump(kDoubleTapTimeout ~/ 2);
+      await tester.tapAt(position);
+      await tester.pump();
+
+      final drag = await tester.startGesture(
+        position,
+        kind: PointerDeviceKind.mouse,
+      );
+      await drag.moveBy(const Offset(60, 0));
+      await tester.pump();
+      await drag.up();
+      await tester.pump();
+
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      expect(focusNode.hasFocus, isFalse);
+      changes.expectBoth(const []);
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.macOS}),
+  );
+
+  testWidgets(
+    'disabled force press does not select or focus the field',
+    (tester) async {
+      final controller = TextEditingController.fromValue(
+        const TextEditingValue(
+          text: 'Disabled force press',
+          selection: TextSelection.collapsed(offset: 0),
+        ),
+      );
+      final focusNode = FocusNode();
+      final changes = _PressChanges();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NakedTextField(
+            controller: controller,
+            focusNode: focusNode,
+            enabled: false,
+            onTapChange: changes.tap.add,
+            onPressChange: changes.aggregate.add,
+            builder: (context, state, editable) => editable,
+          ),
+        ),
+      );
+
+      final position = tester.getCenter(find.byType(EditableText));
+      final pointer = tester.nextPointer;
+      final gesture = await tester.createGesture();
+      await gesture.downWithCustomEvent(
+        position,
+        PointerDownEvent(
+          pointer: pointer,
+          position: position,
+          pressure: 0,
+          pressureMin: 0,
+          pressureMax: 6,
+        ),
+      );
+      await tester.pump(kPressTimeout);
+      await gesture.updateWithCustomEvent(
+        PointerMoveEvent(
+          pointer: pointer,
+          position: position,
+          pressure: 0.5,
+          pressureMin: 0,
+        ),
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      expect(focusNode.hasFocus, isFalse);
+      changes.expectBoth(const []);
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.iOS}),
+  );
+}

--- a/packages/naked_ui/test/src/naked_textfield_press_state_test.dart
+++ b/packages/naked_ui/test/src/naked_textfield_press_state_test.dart
@@ -291,6 +291,55 @@ void main() {
     expect(states, isNot(contains(WidgetState.pressed)));
   });
 
+  testWidgets('removing a pressed field does not notify during teardown', (
+    tester,
+  ) async {
+    final controller = TextEditingController(text: 'Remove while pressed');
+    final changes = _PressChanges();
+    var showField = true;
+    var callbackRebuilds = 0;
+    late StateSetter setHostState;
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            setHostState = setState;
+            return showField
+                ? NakedTextField(
+                    controller: controller,
+                    onTapChange: changes.tap.add,
+                    onPressChange: (pressed) {
+                      changes.aggregate.add(pressed);
+                      if (!pressed) {
+                        setHostState(() => callbackRebuilds++);
+                      }
+                    },
+                    builder: (context, state, editable) => editable,
+                  )
+                : const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(EditableText)),
+    );
+    await tester.pump(kPressTimeout);
+    changes.expectBoth([true]);
+
+    setHostState(() => showField = false);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    changes.expectBoth([true]);
+    expect(callbackRebuilds, 0);
+
+    await gesture.up();
+  });
+
   testWidgets(
     'disabled pointer gestures do not select or focus the field',
     (tester) async {


### PR DESCRIPTION
## Description

Corrects two shared interaction contracts used by Remix components.

`NakedToggleOption` now marks options as members of a mutually exclusive group, matching Flutter's segmented-control semantics while preserving explicit child nodes, controlled selection, and disabled behavior.

`NakedTextField` now keeps its public press callbacks and `WidgetState.pressed` synchronized when multi-tap selection, drag selection, scrolling, or force press takes ownership. Disabled tap, drag, directional-navigation, and force-press paths are gated before Flutter's selection behavior runs.

Adversarial review exposed one lifecycle edge case in that implementation: Flutter's tap tracker also resets when its recognizer is disposed. Forwarding that reset synchronously could invoke a consumer callback that rebuilt an ancestor while the widget tree was locked. The reset now clears internal pressed state immediately, defers consumer callbacks until rebuilding is safe, skips them after unmount, and invalidates stale deferred resets when a newer press transition wins.

This is a behavioral and accessibility correction with no public API or rendered design change, so screenshots are not applicable.

### Validation

- Regression test reproduced `setState() or markNeedsBuild() called when widget tree was locked` on the prior implementation and passes with the lifecycle-safe reset.
- `flutter test test/src/naked_textfield_press_state_test.dart test/src/naked_textfield_test.dart test/semantics/naked_textfield_semantics_test.dart test/src/naked_toggle_test.dart test/semantics/naked_toggle_semantics_test.dart` — 109 passed.
- `flutter test` — 678 passed, 3 intentionally skipped external integration tests.
- `flutter analyze --fatal-infos` — no issues.
- `dart format --output=none --set-exit-if-changed ...` — 0 changed.
- `git diff --check` — clean.
- Final adversarial review — no remaining findings.

## Related Issues

No linked issue was supplied.

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] Existing public doc comments remain accurate; no API documentation change is required.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
