### PR TITLE
chore(release): prepare 1.0.0-beta.9

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.0.0-beta.9
+
+### Fixes
+
+- Keep `NakedTextField`'s `WidgetState.pressed`, `onTapChange`, and
+  `onPressChange` synchronized when selection gestures take over; block
+  disabled pointer and selection paths, and defer lifecycle cleanup callbacks
+  to avoid rebuilding while the widget tree is locked.
+- Mark `NakedToggleOption` semantics as part of a mutually exclusive group,
+  matching Flutter's segmented-control contract for enabled, selected, and
+  disabled options.
+
 ## 1.0.0-beta.8
 
 ### Fixes

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.8
+version: 1.0.0-beta.9
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepares `naked_ui 1.0.0-beta.9` for publication after the interaction and
accessibility fixes merged in #84.

- Bumps the package version from `1.0.0-beta.8` to `1.0.0-beta.9`.
- Adds release notes for lifecycle-safe `NakedTextField` press handling and
  disabled selection gating.
- Adds release notes for mutually-exclusive `NakedToggleOption` semantics.

This PR changes release metadata only; it does not alter the implementation
merged in #84.

## Why

The package metadata still identifies beta.8, while `main` now contains the
fixes intended for the next beta. The version and changelog must be updated
before creating the release tag that triggers the pub.dev workflow.

### Validation

- `dart format --output=none --set-exit-if-changed .` — 148 files checked, 0
  changed.
- `flutter analyze --fatal-infos` — no issues.
- `flutter test` in `packages/naked_ui` — 678 passed, 3 intentionally skipped
  external integration tests.
- `flutter test` in `packages/example` — 23 passed, 3 intentionally skipped
  tests.
- `flutter pub publish --dry-run` — 167 KB archive, 0 warnings.
- `git diff --check origin/main...HEAD` — clean.
- Confirmed no existing local or remote `v1.0.0-beta.9` tag.

## Related Issues

Follow-up release preparation for #84.

---

## Checklist

- [x] The changelog describes every user-visible change included since beta.8.
- [x] The package version matches the intended release tag.
- [x] Formatting, analysis, tests, and publish dry-run pass.
- [x] This PR does not introduce a breaking change.

## Publication

After this PR is reviewed and merged, create and push `v1.0.0-beta.9` from the
resulting `main` commit. The repository release workflow will run Android and
web release gates before publishing to pub.dev.
