### PR TITLE
chore(release): prepare 1.0.0-beta.10

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.0.0-beta.10
+
+### Features
+
+- Add `NakedAccordion.itemBuilder` for styling a trigger and panel as one unit.
+  It receives the same `NakedAccordionItemState` as the trigger builder plus the
+  fully assembled item as its child, and its context resolves
+  `NakedAccordionItemState.controllerOf` to the authoritative controller shared
+  with the trigger and panel.
+
+### Fixes
+
+- Track `NakedAccordion` press state whenever the item is enabled instead of
+  only when `onPressChange` is supplied, so `WidgetState.pressed` reaches
+  builders without a callback, and clear the pressed state when the item
+  becomes disabled.
+
 ## 1.0.0-beta.9
 
 ### Fixes

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.9
+version: 1.0.0-beta.10
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepares `naked_ui 1.0.0-beta.10` for publication after the accordion work
merged in #87.

- Bumps the package version from `1.0.0-beta.9` to `1.0.0-beta.10`.
- Adds release notes for the new `NakedAccordion.itemBuilder` whole-item
  presentation builder.
- Adds release notes for accordion press-state tracking without an
  `onPressChange` callback and pressed-state clearing on disable.

This PR changes release metadata only; it does not alter the implementation
merged in #87.

## Why

The package metadata still identifies beta.9, while `main` now contains the
accordion feature and press-state fix intended for the next beta. The version
and changelog must be updated before creating the release tag that triggers the
pub.dev workflow.

### Validation

- `dart format --set-exit-if-changed .` — 148 files checked, 0 changed.
- `flutter analyze --fatal-infos` — no issues.
- `flutter test` in `packages/naked_ui` — 683 passed, 3 intentionally skipped
  external integration tests.
- `flutter test` in `packages/example` — 23 passed, 3 intentionally skipped
  tests.
- `flutter pub publish --dry-run` — 169 KB archive, 0 warnings.
- `git diff --check origin/main...HEAD` — clean.
- Confirmed no existing local or remote `v1.0.0-beta.10` tag.

## Related Issues

Follow-up release preparation for #87.

---

## Checklist

- [x] The changelog describes every user-visible change included since beta.9.
- [x] The package version matches the intended release tag.
- [x] Formatting, analysis, tests, and publish dry-run pass.
- [x] This PR does not introduce a breaking change.

## Publication

After this PR is reviewed and merged, create and push `v1.0.0-beta.10` from the
resulting `main` commit. The repository release workflow will run Android and
web release gates before publishing to pub.dev.