### PR TITLE
fix(ci): pre-apply Flutter analysis_options migration

### DIFF
--- a/packages/example/analysis_options.yaml
+++ b/packages/example/analysis_options.yaml
@@ -9,6 +9,18 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  # Pre-applied Flutter AnalysisOptionsMigration exclusions. Without all seven
+  # entries, `flutter pub get` rewrites this file and dirties the working tree.
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/packages/naked_ui/analysis_options.yaml
+++ b/packages/naked_ui/analysis_options.yaml
@@ -53,6 +53,19 @@ dart_code_metrics:
     avoid-empty-setstate: false
     
 analyzer:
+  # Flutter's AnalysisOptionsMigration (flutter_tools) rewrites this file during
+  # `flutter pub get` unless `analyzer.exclude` already lists every one of these
+  # seven patterns verbatim. That rewrite dirties the working tree, which makes
+  # `dart pub publish` fail with "checked-in file is modified in git" (exit 65).
+  # Keep this list exact and complete; do not prune or reformat the entries.
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     non_constant_identifier_names: ignore
 


### PR DESCRIPTION
## Description

The `v1.0.0-beta.10` release tag built green through both release gates but
**failed at the pub.dev publish step with exit code 65**:

```
Package validation found the following potential issue:
* 1 checked-in file is modified in git.
  Modified files:
  analysis_options.yaml
```

### Root cause

Nothing in this repo changed. Flutter's `AnalysisOptionsMigration`
([flutter/flutter#187940](https://github.com/flutter/flutter/pull/187940),
landed 2026-06-23) rewrites `analysis_options.yaml` during `flutter pub get`
unless `analyzer.exclude` already contains all seven build/platform patterns.
The publish workflow (`btwld/dart-actions`) runs **unpinned Flutter stable**,
which rolled forward between releases:

| | beta.9 publish (Aug 4) | beta.10 publish (Aug 12) |
|---|---|---|
| Flutter stable | 3.44.8 | 3.47.0 |
| `Upgrading analysis_options` log lines | 0 | 2 |

The rewrite dirtied the working tree mid-job, so `dart pub publish` refused to
publish from a dirty git state.

This never surfaced in PR checks because the repo's own CI pins Flutter
`3.41.2` — the gates and the publisher run different Flutter versions.

### Fix

Pre-apply the exact exclusions the migrator wants, so it takes its no-op path.
Per the [migrator source](https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/lib/src/migrations/analysis_options_migration.dart),
it skips only when `analyzer.exclude` is a YAML list containing every one of
`build/**`, `android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**`,
`linux/**`. Applied to both `packages/naked_ui` and `packages/example` (the
migration ran twice — once per package).

A comment records why the list must stay exact, so a future cleanup pass
doesn't prune it and silently re-break publishing.

### Validation

- `flutter analyze` — no issues.
- `dart format --set-exit-if-changed .` — 148 files, 0 changed.
- `flutter test` in `packages/naked_ui` — 683 passed, 3 intentionally skipped.
- `flutter pub publish --dry-run` on a clean tree — **0 warnings** (was 1).

Local Flutter here is 3.41.2, which predates the migrator, so the no-op is
verified against the migrator's source condition rather than by executing it;
the release job on stable 3.47.0 is the final proof.

## Related Issues

Unblocks publication of `1.0.0-beta.10` (prepared in #88).

---

## Checklist

- [x] No library behavior changes; analyzer configuration only.
- [x] Formatting, analysis, tests, and a clean-tree publish dry-run pass.
- [x] This PR does not introduce a breaking change.

## Follow-up

Two hardening items intentionally left out of this PR:

1. `integration-android.yml` (a release gate) downloads the Gradle distribution
   with no retry; a GitHub 503 already flaked this release once.
2. The gate/publisher Flutter version drift that caused this bug is still
   present — the publish workflow should pin Flutter, or the repo should track
   stable.