### PR TITLE
chore(release): prepare 1.0.0-beta.11

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.11
 
 ### Features
 

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Description

Prepares `naked_ui 1.0.0-beta.11` for publication after `NakedLink` merged in #65.

- Bumps the package version from `1.0.0-beta.10` to `1.0.0-beta.11`.
- Promotes the existing `NakedLink` changelog entry into the beta.11 release notes.

This PR changes release metadata only; it does not alter the implementation merged in #65.

## Why

The package metadata still identifies beta.10, while `main` now contains the `NakedLink` primitive intended for the next beta. The version and changelog must be updated before creating the release tag that triggers the pub.dev workflow.

### Validation

- `dart format --output=none --set-exit-if-changed .` — 154 files checked, 0 changed.
- `flutter analyze --fatal-infos` — no issues.
- `flutter test` in `packages/naked_ui` — 703 passed, 3 intentionally skipped external integration tests.
- `flutter test` in `packages/example` — 26 passed, 3 intentionally skipped tests.
- `flutter pub publish --dry-run` — 175 KB archive, 0 warnings.
- `git diff --check origin/main...HEAD` — clean.
- Confirmed no existing remote `v1.0.0-beta.11` tag.

## Related Issues

Follow-up release preparation for #65.

---

## Checklist

- [x] The changelog describes every user-visible change included since beta.10.
- [x] The package version matches the intended release tag.
- [x] Formatting, analysis, tests, and publish dry-run pass.
- [x] This PR does not introduce a breaking change.

## Publication

After this PR is merged, create and push `v1.0.0-beta.11` from the resulting `main` commit. The repository release workflow will run Android and web release gates before publishing to pub.dev.
