### PR TITLE
chore(release): prepare 1.0.0-beta.12

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.12
 
 ### Features
 

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.11
+version: 1.0.0-beta.12
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## What

Cuts `1.0.0-beta.12`: promotes the `Unreleased` CHANGELOG section and bumps `packages/naked_ui/pubspec.yaml`.

## Contents

One feature PR landed since `1.0.0-beta.11`:

- **#91 — semantic adapter APIs for visual-layer consumers**: `NakedButton.semanticHint`, `NakedSelect.semanticValue`, and `NakedRadioGroup<T>` (a thin wrapper over Flutter's `RadioGroup` supplying a nullable `onChanged`, an inherited group `enabled` state, and an accessible group label). `NakedRadioGroupScope` is intentionally hidden from the public barrel — it is internal plumbing, mirroring Flutter's private `_RadioGroupStateScope<T>`.

## Verification

- `flutter analyze`: no issues.
- `flutter test`: 712 passed, 3 skipped.
- `flutter pub publish --dry-run`: clean (only the pre-commit "modified files" warning, resolved by this commit).

## After merge

Publishing is tag-driven (`.github/workflows/release.yml` on `v[0-9]+.[0-9]+.[0-9]+*`). Tag `v1.0.0-beta.12` on `main` to publish to pub.dev.