### PR TITLE
feat: add standalone disclosure primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The complete documentation covers detailed component APIs and examples, guides a
 - NakedToggle — toggle button or switch behavior
 - NakedTabs — tablist + roving focus
 - NakedAccordion — expandable/collapsible sections
+- NakedDisclosure — standalone show/hide button and panel
 - NakedMenu — anchored overlay menu
 - NakedDialog — normal and alert dialog semantics + modal focus trap
 - NakedTooltip — anchored tooltip with lifecycle

--- a/docs.json
+++ b/docs.json
@@ -66,6 +66,10 @@
           "href": "/widget/dialog"
         },
         {
+          "title": "NakedDisclosure",
+          "href": "/widget/disclosure"
+        },
+        {
           "title": "NakedLink",
           "href": "/widget/link"
         },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -71,6 +71,7 @@ Components handle behavior. Builders define appearance.
 - NakedToggle - toggle button or switch behavior
 - NakedTabs - tablist + roving focus
 - NakedAccordion - expandable/collapsible sections
+- NakedDisclosure - standalone show/hide button and panel
 - NakedMenu - anchored overlay menu
 - NakedDialog - modal dialog behavior + focus trap
 - NakedLink - link semantics, activation, and observable interaction state
@@ -215,6 +216,7 @@ All components follow the same builder pattern. Choose based on interaction requ
 ### For organizing content
 - **[Tabs](/widget/tabs)** - Switch between different content sections
 - **[Accordion](/widget/accordion)** - Expandable sections (FAQ, settings groups)
+- **[Disclosure](/widget/disclosure)** - Independently show or hide one content section
 - **[Dialog](/widget/dialog)** - Modal windows (confirmations, forms)
 
 ### For helpful overlays

--- a/docs/widget/disclosure.mdx
+++ b/docs/widget/disclosure.mdx
@@ -1,0 +1,164 @@
+---
+title: NakedDisclosure
+description: Headless disclosure button and panel with controlled state, accessible semantics, and optional exit-aware transitions
+keywords: [flutter, disclosure, show hide, expansion, headless, accessibility]
+---
+
+`NakedDisclosure` is a headless button that shows or hides one content panel. It
+implements the [WAI-ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/):
+the trigger has button semantics, reports whether its panel is expanded, and
+activates with Enter or Space.
+
+<Info>
+  A complete example lives in [`packages/example/lib/api/naked_disclosure.0.dart`](https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_disclosure.0.dart).
+</Info>
+
+## Disclosure or accordion?
+
+Use `NakedDisclosure` for an independent button controlling one section, such
+as optional details or a single help answer. Use `NakedAccordionGroup` and
+`NakedAccordion` when multiple sections form a coordinated collection with
+minimum or maximum expansion rules.
+
+## Uncontrolled disclosure
+
+An uncontrolled disclosure owns its state. `defaultExpanded` is read only when
+the widget is initialized; later changes are intentionally ignored.
+
+```dart
+NakedDisclosure(
+  defaultExpanded: false,
+  child: const Text('Show shipping details'),
+  builder: (context, state, child) => Row(
+    children: [
+      Expanded(child: child!),
+      AnimatedRotation(
+        turns: state.isExpanded ? 0.5 : 0,
+        duration: const Duration(milliseconds: 200),
+        child: const Icon(Icons.keyboard_arrow_down),
+      ),
+    ],
+  ),
+  panel: const Text('Ships in 2–3 business days.'),
+)
+```
+
+At least one of `child` or `builder` is required. Supply both when the builder
+should decorate static trigger content. The component supplies no styling or
+icons.
+
+## Controlled disclosure
+
+Set `expanded` to make the owner the source of truth. Activation requests the
+inverse value through `onExpandedChanged`; the panel changes only when the
+owner accepts and supplies the new value.
+
+```dart
+NakedDisclosure(
+  expanded: detailsOpen,
+  onExpandedChanged: (value) => setState(() => detailsOpen = value),
+  child: const Text('Delivery details'),
+  panel: const Text('Tracking is included.'),
+)
+```
+
+A controlled disclosure without `onExpandedChanged` is read-only. Its panel
+still reflects `expanded`, but the trigger is disabled and exposes no tap
+action. An uncontrolled disclosure remains interactive without a callback.
+Setting `enabled: false` disables only the trigger; descendants of an already
+expanded panel remain available.
+
+## Styling state
+
+`builder` and `itemBuilder` receive one authoritative `NakedDisclosureState`.
+It exposes `isExpanded` and the standard hovered, focused, pressed, disabled,
+and selected states. `WidgetState.selected` always mirrors expansion.
+
+Use `itemBuilder` for decoration around the complete trigger and panel. Its
+supplied child preserves the trigger's original hit target, so the panel does
+not become part of the disclosure button.
+
+```dart
+itemBuilder: (context, state, child) => DecoratedBox(
+  decoration: BoxDecoration(
+    border: Border.all(color: state.isFocused ? Colors.blue : Colors.grey),
+  ),
+  child: child,
+),
+```
+
+The same state is available below the scope through
+`NakedDisclosureState.of(context)`. Use `controllerOf(context)` when a
+descendant needs the stable `WidgetStatesController` identity.
+
+## Panel transitions and lifecycle
+
+Without `transitionBuilder`, panel mount and removal are immediate. With a
+transition, the real panel mounts before the forward animation and stays
+mounted through the reverse animation. It is removed after dismissal; there is
+no persistent collapsed panel state.
+
+```dart
+transitionBuilder: (context, animation, child) => FadeTransition(
+  opacity: animation,
+  child: SizeTransition(
+    sizeFactor: animation,
+    axisAlignment: -1,
+    child: child,
+  ),
+),
+```
+
+Custom transitions default to 200ms with `Curves.ease`. Configure
+`animationStyle` to change the forward and reverse timing. Expansion remains
+immediate when no transition builder is supplied. `AnimationStyle.noAnimation`
+and the platform reduced-motion preference snap to the requested state.
+
+As soon as closing begins, the retained panel is excluded from semantics,
+pointer input, focus, and focus traversal. Rapid close/open changes safely
+reverse the same transition without allowing a stale dismissal to remove the
+reopened panel.
+
+## Accessibility
+
+- The trigger is the only button and the only disclosure tap target.
+- Visible trigger text supplies the accessible name by default.
+- A non-empty `semanticLabel` replaces trigger-descendant semantics; use
+  `semanticHint` for short additional context.
+- `excludeSemantics: true` hides both the trigger and panel.
+- Opening keeps focus on the trigger. If an interactive disclosure collapses
+  while a panel descendant is focused, focus returns to the trigger.
+- Enter, Space, numpad Enter, pointer tap, and semantic tap activate the same
+  behavior.
+
+Do not place links, buttons, text fields, or other interactive controls inside
+the trigger. Put them in the panel so each control keeps a separate hit target,
+focus stop, and semantic action.
+
+## Constructor
+
+```dart
+const NakedDisclosure({
+  Key? key,
+  Widget? child,
+  ValueWidgetBuilder<NakedDisclosureState>? builder,
+  required Widget panel,
+  ValueWidgetBuilder<NakedDisclosureState>? itemBuilder,
+  bool? expanded,
+  bool defaultExpanded = false,
+  ValueChanged<bool>? onExpandedChanged,
+  bool enabled = true,
+  MouseCursor mouseCursor = SystemMouseCursors.click,
+  bool enableFeedback = true,
+  FocusNode? focusNode,
+  bool autofocus = false,
+  ValueChanged<bool>? onFocusChange,
+  ValueChanged<bool>? onHoverChange,
+  ValueChanged<bool>? onPressChange,
+  String? semanticLabel,
+  String? semanticHint,
+  bool excludeSemantics = false,
+  NakedDisclosureTransitionBuilder? transitionBuilder,
+  AnimationStyle animationStyle = const AnimationStyle(...),
+})
+```

--- a/packages/example/lib/api/naked_disclosure.0.dart
+++ b/packages/example/lib/api/naked_disclosure.0.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+class DisclosureExample extends StatefulWidget {
+  const DisclosureExample({super.key});
+
+  @override
+  State<DisclosureExample> createState() => _DisclosureExampleState();
+}
+
+class _DisclosureExampleState extends State<DisclosureExample> {
+  bool _showDeliveryDetails = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: 360,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _UncontrolledDisclosure(),
+            const SizedBox(height: 16),
+            NakedDisclosure(
+              expanded: _showDeliveryDetails,
+              onExpandedChanged: (value) {
+                setState(() => _showDeliveryDetails = value);
+              },
+              builder: _buildTrigger,
+              panel: const Padding(
+                padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text('Ships in 2–3 business days with tracking.'),
+                ),
+              ),
+              transitionBuilder: (context, animation, child) => FadeTransition(
+                opacity: animation,
+                child: SizeTransition(
+                  sizeFactor: animation,
+                  axisAlignment: -1,
+                  child: child,
+                ),
+              ),
+              itemBuilder: _buildItem,
+              child: const Text('Delivery details'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UncontrolledDisclosure extends StatelessWidget {
+  const _UncontrolledDisclosure();
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedDisclosure(
+      defaultExpanded: true,
+      semanticHint: 'Shows or hides return policy details',
+      builder: _buildTrigger,
+      panel: const Padding(
+        padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Text('Unused items can be returned within 30 days.'),
+        ),
+      ),
+      transitionBuilder: (context, animation, child) => FadeTransition(
+        opacity: animation,
+        child: SizeTransition(
+          sizeFactor: animation,
+          axisAlignment: -1,
+          child: child,
+        ),
+      ),
+      itemBuilder: _buildItem,
+      child: const Text('What is the return policy?'),
+    );
+  }
+}
+
+Widget _buildTrigger(
+  BuildContext context,
+  NakedDisclosureState state,
+  Widget? child,
+) {
+  final color = state.when(
+    disabled: Colors.grey.shade200,
+    pressed: Colors.blue.shade100,
+    hovered: Colors.blue.shade50,
+    focused: Colors.blue.shade50,
+    orElse: Colors.white,
+  );
+
+  return AnimatedContainer(
+    duration: const Duration(milliseconds: 120),
+    padding: const EdgeInsets.all(16),
+    color: color,
+    child: Row(
+      children: [
+        Expanded(
+          child: DefaultTextStyle.merge(
+            style: const TextStyle(fontWeight: FontWeight.w600),
+            child: child!,
+          ),
+        ),
+        AnimatedRotation(
+          turns: state.isExpanded ? 0.5 : 0,
+          duration: const Duration(milliseconds: 200),
+          child: const Icon(Icons.keyboard_arrow_down_rounded),
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _buildItem(
+  BuildContext context,
+  NakedDisclosureState state,
+  Widget? child,
+) {
+  return DecoratedBox(
+    decoration: BoxDecoration(
+      color: Colors.white,
+      border: Border.all(
+        color: state.isFocused ? Colors.blue : Colors.grey.shade300,
+        width: state.isFocused ? 2 : 1,
+      ),
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: ClipRRect(borderRadius: BorderRadius.circular(11), child: child),
+  );
+}

--- a/packages/example/lib/registry.dart
+++ b/packages/example/lib/registry.dart
@@ -9,6 +9,8 @@ import 'api/naked_button.1.dart' as button_builder_example;
 import 'api/naked_checkbox.0.dart' as checkbox_basic_example;
 // Dialog
 import 'api/naked_dialog.0.dart' as dialog_basic_example;
+// Disclosure
+import 'api/naked_disclosure.0.dart' as disclosure_example;
 // Link
 import 'api/naked_link.0.dart' as link_example;
 // Menu
@@ -177,6 +179,15 @@ class DemoRegistry {
       sourceUrl:
           'https://github.com/btwld/naked_ui/blob/main/example/lib/api/naked_dialog.0.dart',
       tags: ['dialog', 'alert'],
+    ),
+    Demo(
+      id: 'disclosure-basic',
+      title: 'Disclosure – Controlled and uncontrolled',
+      category: 'Disclosure',
+      builder: (_) => const disclosure_example.DisclosureExample(),
+      sourceUrl:
+          'https://github.com/btwld/naked_ui/blob/main/packages/example/lib/api/naked_disclosure.0.dart',
+      tags: ['disclosure', 'expansion', 'accessibility'],
     ),
     Demo(
       id: 'link-basic',

--- a/packages/naked_ui/README.md
+++ b/packages/naked_ui/README.md
@@ -25,6 +25,7 @@ The complete documentation covers detailed component APIs and examples, guides a
 - NakedToggle — toggle button or switch behavior
 - NakedTabs — tablist + roving focus
 - NakedAccordion — expandable/collapsible sections
+- NakedDisclosure — standalone show/hide button and panel
 - NakedMenu — anchored menu with checkbox/radio items + recursive submenus
 - NakedDialog — normal and alert dialog semantics + modal focus trap
 - NakedTooltip — controlled, hoverable, collision-aware tooltip

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -1,0 +1,482 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'mixins/naked_mixins.dart';
+import 'utilities/intents.dart';
+import 'utilities/naked_focusable_detector.dart';
+import 'utilities/naked_state_scope.dart';
+import 'utilities/state.dart';
+
+/// Builds a transition around a disclosure panel.
+///
+/// The [animation] runs from zero to one while the panel opens and from one to
+/// zero while it closes. The real panel remains mounted until the closing
+/// animation is dismissed.
+typedef NakedDisclosureTransitionBuilder =
+    Widget Function(
+      BuildContext context,
+      Animation<double> animation,
+      Widget child,
+    );
+
+/// Immutable view passed to [NakedDisclosure.builder] and
+/// [NakedDisclosure.itemBuilder].
+class NakedDisclosureState extends NakedState {
+  /// Creates an immutable disclosure state snapshot.
+  NakedDisclosureState({required super.states, required this.isExpanded});
+
+  /// Whether the disclosure panel is expanded.
+  final bool isExpanded;
+
+  /// Returns the nearest [NakedDisclosureState] provided by
+  /// [NakedStateScope].
+  static NakedDisclosureState of(BuildContext context) =>
+      NakedState.of(context);
+
+  /// Returns the nearest [NakedDisclosureState], if one is available.
+  static NakedDisclosureState? maybeOf(BuildContext context) =>
+      NakedState.maybeOf(context);
+
+  /// Returns the [WidgetStatesController] from the nearest state scope.
+  static WidgetStatesController controllerOf(BuildContext context) =>
+      NakedState.controllerOf<NakedDisclosureState>(context);
+
+  /// Returns the nearest state scope's controller, if one is available.
+  static WidgetStatesController? maybeControllerOf(BuildContext context) =>
+      NakedState.maybeControllerOf<NakedDisclosureState>(context);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is NakedDisclosureState &&
+        other.isExpanded == isExpanded &&
+        statesEqual(other);
+  }
+
+  @override
+  int get hashCode => Object.hash(statesHashCode, isExpanded);
+}
+
+/// A headless disclosure button controlling one content panel.
+///
+/// When [expanded] is null, the disclosure owns its expansion state and starts
+/// from [defaultExpanded]. When [expanded] is non-null, activation requests a
+/// new value through [onExpandedChanged] and the owner remains the source of
+/// truth.
+///
+/// The [builder] decorates the optional static [child]. The [itemBuilder]
+/// decorates the complete trigger-and-panel item without changing the trigger
+/// hit target.
+class NakedDisclosure extends StatefulWidget {
+  /// Creates a headless disclosure.
+  const NakedDisclosure({
+    super.key,
+    this.child,
+    this.builder,
+    required this.panel,
+    this.itemBuilder,
+    this.expanded,
+    this.defaultExpanded = false,
+    this.onExpandedChanged,
+    this.enabled = true,
+    this.mouseCursor = SystemMouseCursors.click,
+    this.enableFeedback = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.onFocusChange,
+    this.onHoverChange,
+    this.onPressChange,
+    this.semanticLabel,
+    this.semanticHint,
+    this.excludeSemantics = false,
+    this.transitionBuilder,
+    this.animationStyle = const AnimationStyle(
+      curve: Curves.ease,
+      duration: Duration(milliseconds: 200),
+      reverseDuration: Duration(milliseconds: 200),
+    ),
+  }) : assert(
+         child != null || builder != null,
+         'Either child or builder must be provided.',
+       );
+
+  /// Static content supplied to [builder], or used directly as the trigger.
+  final Widget? child;
+
+  /// Builds the trigger using the current [NakedDisclosureState].
+  final ValueWidgetBuilder<NakedDisclosureState>? builder;
+
+  /// Content controlled by the disclosure trigger.
+  final Widget panel;
+
+  /// Builds a presentation wrapper around the assembled trigger and panel.
+  ///
+  /// The callback context is below the disclosure state scope. The supplied
+  /// child must remain in the returned subtree to preserve behavior.
+  final ValueWidgetBuilder<NakedDisclosureState>? itemBuilder;
+
+  /// Whether the panel is expanded when controlled, or null when uncontrolled.
+  final bool? expanded;
+
+  /// Initial expansion for an uncontrolled disclosure.
+  ///
+  /// Changes after initialization are ignored.
+  final bool defaultExpanded;
+
+  /// Called when activation requests an expansion change.
+  final ValueChanged<bool>? onExpandedChanged;
+
+  /// Whether disclosure-trigger interaction is enabled.
+  final bool enabled;
+
+  /// Mouse cursor used while the trigger is interactive.
+  final MouseCursor mouseCursor;
+
+  /// Whether activation provides platform feedback.
+  final bool enableFeedback;
+
+  /// Focus node associated with the trigger.
+  final FocusNode? focusNode;
+
+  /// Whether the trigger requests focus when first built.
+  final bool autofocus;
+
+  /// Called when trigger focus changes.
+  final ValueChanged<bool>? onFocusChange;
+
+  /// Called when trigger hover changes.
+  final ValueChanged<bool>? onHoverChange;
+
+  /// Called when trigger press state changes.
+  final ValueChanged<bool>? onPressChange;
+
+  /// Accessible name that replaces trigger-descendant semantics when non-empty.
+  final String? semanticLabel;
+
+  /// Additional context announced with the trigger's accessible name.
+  final String? semanticHint;
+
+  /// Whether to hide the trigger and panel from the semantics tree.
+  final bool excludeSemantics;
+
+  /// Optional transition applied to the panel.
+  ///
+  /// Without a transition builder, expansion and collapse are immediate.
+  final NakedDisclosureTransitionBuilder? transitionBuilder;
+
+  /// Curves and durations used by [transitionBuilder].
+  final AnimationStyle animationStyle;
+
+  @override
+  State<NakedDisclosure> createState() => _NakedDisclosureState();
+}
+
+class _NakedDisclosureState extends State<NakedDisclosure>
+    with
+        WidgetStatesMixin<NakedDisclosure>,
+        FocusNodeMixin<NakedDisclosure>,
+        SingleTickerProviderStateMixin<NakedDisclosure> {
+  Timer? _keyboardPressTimer;
+  final FocusNode _panelFocusNode = FocusNode(
+    debugLabel: 'NakedDisclosure panel',
+  );
+  late final AnimationController _animationController;
+  late CurvedAnimation _animation;
+  late bool _uncontrolledExpanded;
+  late bool _panelMounted;
+  bool _animationsDisabled = false;
+  int _transitionGeneration = 0;
+
+  bool get _isControlled => widget.expanded != null;
+
+  bool get _isExpanded => widget.expanded ?? _uncontrolledExpanded;
+
+  bool get _isInteractive =>
+      widget.enabled && (!_isControlled || widget.onExpandedChanged != null);
+
+  bool get _shouldAnimate =>
+      widget.transitionBuilder != null &&
+      widget.animationStyle != AnimationStyle.noAnimation &&
+      !_animationsDisabled;
+
+  Duration get _forwardDuration =>
+      widget.animationStyle.duration ?? const Duration(milliseconds: 200);
+
+  Duration get _reverseDuration =>
+      widget.animationStyle.reverseDuration ??
+      const Duration(milliseconds: 200);
+
+  Curve get _forwardCurve => widget.animationStyle.curve ?? Curves.ease;
+
+  Curve get _reverseCurve =>
+      widget.animationStyle.reverseCurve ?? _forwardCurve.flipped;
+
+  @override
+  FocusNode? get widgetProvidedNode => widget.focusNode;
+
+  @override
+  void initializeWidgetStates() {
+    updateDisabledState(!_isInteractive);
+    updateSelectedState(_isExpanded, null);
+  }
+
+  @override
+  void initState() {
+    // WidgetStatesMixin initializes state from _isExpanded in super.initState.
+    _uncontrolledExpanded = widget.defaultExpanded;
+    _panelMounted = _isExpanded;
+    super.initState();
+    _animationController = AnimationController(
+      value: _isExpanded ? 1 : 0,
+      duration: _forwardDuration,
+      reverseDuration: _reverseDuration,
+      vsync: this,
+    );
+    _animation = _createAnimation();
+  }
+
+  CurvedAnimation _createAnimation() => CurvedAnimation(
+    parent: _animationController,
+    curve: _forwardCurve,
+    reverseCurve: _reverseCurve,
+  );
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final animationsDisabled =
+        MediaQuery.maybeDisableAnimationsOf(context) ?? false;
+    if (_animationsDisabled == animationsDisabled) return;
+    _animationsDisabled = animationsDisabled;
+    _applyExpansion();
+  }
+
+  @override
+  void didUpdateWidget(covariant NakedDisclosure oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldExpanded = oldWidget.expanded ?? _uncontrolledExpanded;
+
+    if (oldWidget.expanded != null && widget.expanded == null) {
+      _uncontrolledExpanded = oldWidget.expanded!;
+    }
+
+    if (widget.animationStyle != oldWidget.animationStyle) {
+      _animationController
+        ..duration = _forwardDuration
+        ..reverseDuration = _reverseDuration;
+      _animation.dispose();
+      _animation = _createAnimation();
+    }
+
+    final interactionChanged =
+        oldWidget.enabled != widget.enabled ||
+        oldWidget.expanded != widget.expanded ||
+        oldWidget.onExpandedChanged != widget.onExpandedChanged;
+    if (interactionChanged) {
+      updateDisabledState(!_isInteractive);
+      if (!_isInteractive) {
+        _cleanupKeyboardPress();
+        updatePressState(false, widget.onPressChange);
+      }
+    }
+
+    updateSelectedState(_isExpanded, null);
+    if (oldExpanded != _isExpanded ||
+        oldWidget.transitionBuilder != widget.transitionBuilder ||
+        oldWidget.animationStyle != widget.animationStyle) {
+      _applyExpansion();
+    }
+  }
+
+  void _cleanupKeyboardPress() {
+    _keyboardPressTimer?.cancel();
+    _keyboardPressTimer = null;
+  }
+
+  void _requestToggle() {
+    if (!_isInteractive) return;
+    final nextExpanded = !_isExpanded;
+
+    if (!_isControlled) {
+      _uncontrolledExpanded = nextExpanded;
+      updateSelectedState(nextExpanded, null);
+      _applyExpansion();
+    }
+
+    widget.onExpandedChanged?.call(nextExpanded);
+  }
+
+  void _handleTap() {
+    if (!_isInteractive) return;
+    if (widget.enableFeedback) Feedback.forTap(context);
+    _requestToggle();
+  }
+
+  void _handleKeyboardActivation() {
+    if (!_isInteractive) return;
+    if (widget.enableFeedback) Feedback.forTap(context);
+    _requestToggle();
+    updatePressState(true, widget.onPressChange);
+    _cleanupKeyboardPress();
+    _keyboardPressTimer = Timer(const Duration(milliseconds: 100), () {
+      if (mounted) updatePressState(false, widget.onPressChange);
+      _keyboardPressTimer = null;
+    });
+  }
+
+  void _applyExpansion() {
+    final generation = ++_transitionGeneration;
+    if (!_isExpanded && _panelFocusNode.hasFocus) {
+      if (_isInteractive) {
+        requestEffectiveFocus();
+      } else {
+        _panelFocusNode.unfocus();
+      }
+    }
+
+    if (!_shouldAnimate) {
+      _animationController
+        ..stop()
+        ..value = _isExpanded ? 1 : 0;
+      _panelMounted = _isExpanded;
+
+      return;
+    }
+
+    if (_isExpanded) {
+      _panelMounted = true;
+      _animationController.forward();
+
+      return;
+    }
+
+    unawaited(_reverseAndUnmount(generation));
+  }
+
+  Future<void> _reverseAndUnmount(int generation) async {
+    await _animationController.reverse();
+    if (!mounted || generation != _transitionGeneration || _isExpanded) {
+      return;
+    }
+    setState(() => _panelMounted = false);
+  }
+
+  Widget _buildPanel(BuildContext context) {
+    final panelHidden = !_isExpanded;
+    final panel = Focus(
+      focusNode: _panelFocusNode,
+      canRequestFocus: false,
+      skipTraversal: true,
+      includeSemantics: false,
+      child: widget.panel,
+    );
+    final transitionBuilder = widget.transitionBuilder;
+    final transitionedPanel = transitionBuilder == null
+        ? panel
+        : transitionBuilder(context, _animation, panel);
+
+    return ExcludeSemantics(
+      excluding: panelHidden,
+      child: IgnorePointer(
+        ignoring: panelHidden,
+        child: ExcludeFocusTraversal(
+          excluding: panelHidden,
+          child: ExcludeFocus(excluding: panelHidden, child: transitionedPanel),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _cleanupKeyboardPress();
+    _panelFocusNode.dispose();
+    _animation.dispose();
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final disclosureState = NakedDisclosureState(
+      states: widgetStates,
+      isExpanded: _isExpanded,
+    );
+
+    final scopedItem = NakedStateScope<NakedDisclosureState>(
+      value: disclosureState,
+      child: Builder(
+        builder: (context) {
+          final trigger =
+              widget.builder?.call(context, disclosureState, widget.child) ??
+              widget.child!;
+          final semanticLabel = widget.semanticLabel;
+          final hasReplacementLabel = semanticLabel?.trim().isNotEmpty ?? false;
+          final triggerContent = GestureDetector(
+            onTapDown: _isInteractive
+                ? (_) => updatePressState(true, widget.onPressChange)
+                : null,
+            onTapUp: _isInteractive
+                ? (_) => updatePressState(false, widget.onPressChange)
+                : null,
+            onTap: _isInteractive ? _handleTap : null,
+            onTapCancel: _isInteractive
+                ? () => updatePressState(false, widget.onPressChange)
+                : null,
+            behavior: HitTestBehavior.opaque,
+            excludeFromSemantics: true,
+            child: trigger,
+          );
+
+          final semanticTrigger = Semantics(
+            enabled: _isInteractive,
+            button: true,
+            expanded: _isExpanded,
+            label: hasReplacementLabel ? semanticLabel : null,
+            hint: widget.semanticHint,
+            excludeSemantics: hasReplacementLabel,
+            onTap: _isInteractive ? _handleTap : null,
+            child: triggerContent,
+          );
+
+          final focusableTrigger = NakedFocusableDetector(
+            enabled: _isInteractive,
+            autofocus: widget.autofocus,
+            onFocusChange: (focused) =>
+                updateFocusState(focused, widget.onFocusChange),
+            onHoverChange: (hovered) =>
+                updateHoverState(hovered, widget.onHoverChange),
+            focusNode: effectiveFocusNode,
+            mouseCursor: _isInteractive
+                ? widget.mouseCursor
+                : SystemMouseCursors.basic,
+            shortcuts: NakedIntentActions.button.shortcuts,
+            actions: NakedIntentActions.button.actions(
+              onPressed: _handleKeyboardActivation,
+            ),
+            child: semanticTrigger,
+          );
+
+          final children = <Widget>[focusableTrigger];
+          if (_panelMounted) children.add(_buildPanel(context));
+          final assembledItem = Column(
+            mainAxisSize: MainAxisSize.min,
+            children: children,
+          );
+          final itemBuilder = widget.itemBuilder;
+
+          return itemBuilder == null
+              ? assembledItem
+              : itemBuilder(context, disclosureState, assembledItem);
+        },
+      ),
+    );
+
+    return ExcludeSemantics(
+      excluding: widget.excludeSemantics,
+      child: scopedItem,
+    );
+  }
+}

--- a/packages/naked_ui/lib/src/naked_widgets.dart
+++ b/packages/naked_ui/lib/src/naked_widgets.dart
@@ -2,6 +2,7 @@ export 'naked_accordion.dart';
 export 'naked_button.dart';
 export 'naked_checkbox.dart';
 export 'naked_dialog.dart';
+export 'naked_disclosure.dart';
 export 'naked_link.dart';
 export 'naked_menu.dart';
 export 'naked_popover.dart';

--- a/packages/naked_ui/test/hashcode_contract_test.dart
+++ b/packages/naked_ui/test/hashcode_contract_test.dart
@@ -58,6 +58,12 @@ void main() {
         create: (states) => NakedButtonState(states: states),
       ),
       _ContractCase(
+        description: 'NakedDisclosureState',
+        orderedStates: [WidgetState.selected, WidgetState.focused],
+        create: (states) =>
+            NakedDisclosureState(states: states, isExpanded: true),
+      ),
+      _ContractCase(
         description: 'NakedPopoverState',
         orderedStates: [WidgetState.hovered, WidgetState.pressed],
         create: (states) => NakedPopoverState(states: states, isOpen: true),
@@ -184,6 +190,13 @@ void main() {
       // Different content = not equal
       expect(state1 == state2, isFalse);
       // hashCodes MAY differ (but don't have to - collisions are allowed)
+    });
+
+    test('NakedDisclosureState expansion participates in equality', () {
+      final collapsed = NakedDisclosureState(states: {}, isExpanded: false);
+      final expanded = NakedDisclosureState(states: {}, isExpanded: true);
+
+      expect(collapsed, isNot(expanded));
     });
   });
 }

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -1,0 +1,232 @@
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import 'semantics_test_utils.dart';
+
+int _accessibleLabelCount(WidgetTester tester, String label) => tester.semantics
+    .simulatedAccessibilityTraversal()
+    .where((node) => node.getSemanticsData().label == label)
+    .length;
+
+void main() {
+  Widget buildApp(Widget child) => MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  );
+
+  group('NakedDisclosure semantics', () {
+    testWidgets('exposes one named button with enabled and expanded flags', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          const NakedDisclosure(
+            defaultExpanded: true,
+            child: Text('Details'),
+            panel: Text('Panel content'),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.text('Details')),
+        matchesSemantics(
+          label: 'Details',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+      final root = tester.getSemantics(find.byType(Scaffold));
+      expect(
+        countSemanticsNodes(
+          root,
+          (node) => node.getSemanticsData().flagsCollection.isButton,
+        ),
+        1,
+      );
+      handle.dispose();
+      expect(
+        countSemanticsNodes(
+          root,
+          (node) => node.getSemanticsData().hasAction(SemanticsAction.tap),
+        ),
+        1,
+      );
+    });
+
+    testWidgets('uses visible label for empty or whitespace labels', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      for (final semanticLabel in ['', '   ']) {
+        await tester.pumpWidget(
+          buildApp(
+            NakedDisclosure(
+              semanticLabel: semanticLabel,
+              child: const Text('Visible label'),
+              panel: const Text('Panel'),
+            ),
+          ),
+        );
+
+        expect(
+          tester.getSemantics(find.text('Visible label')),
+          matchesSemantics(
+            label: 'Visible label',
+            isButton: true,
+            hasEnabledState: true,
+            isEnabled: true,
+            isFocusable: true,
+            hasExpandedState: true,
+            isExpanded: false,
+            hasTapAction: true,
+            hasFocusAction: true,
+          ),
+        );
+      }
+      handle.dispose();
+    });
+
+    testWidgets(
+      'explicit label and hint replace descendants without duplication',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildApp(
+            const NakedDisclosure(
+              semanticLabel: 'Accessible details',
+              semanticHint: 'Shows technical information',
+              child: Text('Visible details'),
+              panel: Text('Panel'),
+            ),
+          ),
+        );
+
+        final node = tester.getSemantics(find.text('Visible details'));
+        final data = node.getSemanticsData();
+        expect(data.label, 'Accessible details');
+        expect(data.hint, 'Shows technical information');
+        expect(data.label, isNot(contains('Visible details')));
+        final root = tester.getSemantics(find.byType(Scaffold));
+        expect(
+          countSemanticsNodes(
+            root,
+            (candidate) => candidate.getSemanticsData().label.contains(
+              'Accessible details',
+            ),
+          ),
+          1,
+        );
+        handle.dispose();
+      },
+    );
+
+    testWidgets('read-only controlled trigger is disabled with no tap action', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          const NakedDisclosure(
+            expanded: true,
+            child: Text('Read only'),
+            panel: Text('Available panel'),
+          ),
+        ),
+      );
+
+      final data = tester
+          .getSemantics(find.text('Read only'))
+          .getSemanticsData();
+      expect(data.flagsCollection.isButton, isTrue);
+      expect(data.flagsCollection.isEnabled, Tristate.isFalse);
+      expect(data.flagsCollection.isExpanded, Tristate.isTrue);
+      expect(data.hasAction(SemanticsAction.tap), isFalse);
+      expect(find.bySemanticsLabel('Available panel'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('expanded panel is exposed and closing panel is excluded', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          NakedDisclosure(
+            defaultExpanded: true,
+            child: const Text('Trigger'),
+            panel: const Text('Panel semantics'),
+            transitionBuilder: (context, animation, child) =>
+                FadeTransition(opacity: animation, child: child),
+          ),
+        ),
+      );
+      expect(_accessibleLabelCount(tester, 'Panel semantics'), 1);
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel semantics'), findsOneWidget);
+      expect(_accessibleLabelCount(tester, 'Panel semantics'), 0);
+      await tester.pumpAndSettle();
+      expect(find.text('Panel semantics'), findsNothing);
+      handle.dispose();
+    });
+
+    testWidgets('excludeSemantics updates without remounting or leaking', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      var excludeSemantics = false;
+      late StateSetter rebuild;
+      await tester.pumpWidget(
+        buildApp(
+          StatefulBuilder(
+            builder: (context, setState) {
+              rebuild = setState;
+              return NakedDisclosure(
+                excludeSemantics: excludeSemantics,
+                defaultExpanded: true,
+                child: const Text('Toggleable trigger'),
+                panel: const Text('Toggleable panel'),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(_accessibleLabelCount(tester, 'Toggleable trigger'), 1);
+      expect(_accessibleLabelCount(tester, 'Toggleable panel'), 1);
+
+      rebuild(() => excludeSemantics = true);
+      await tester.pump();
+
+      expect(_accessibleLabelCount(tester, 'Toggleable trigger'), 0);
+      expect(_accessibleLabelCount(tester, 'Toggleable panel'), 0);
+      final leaked = tester.semantics.simulatedAccessibilityTraversal().where((
+        node,
+      ) {
+        final data = node.getSemanticsData();
+        return data.flagsCollection.isButton ||
+            data.flagsCollection.isExpanded != Tristate.none ||
+            data.hasAction(SemanticsAction.tap);
+      }).toList();
+      expect(leaked, isEmpty);
+
+      rebuild(() => excludeSemantics = false);
+      await tester.pump();
+      expect(_accessibleLabelCount(tester, 'Toggleable trigger'), 1);
+      expect(_accessibleLabelCount(tester, 'Toggleable panel'), 1);
+      handle.dispose();
+    });
+  });
+}

--- a/packages/naked_ui/test/src/naked_disclosure_test.dart
+++ b/packages/naked_ui/test/src/naked_disclosure_test.dart
@@ -1,0 +1,815 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('state ownership', () {
+    testWidgets('starts collapsed or from defaultExpanded', (tester) async {
+      await tester.pumpMaterialWidget(
+        const Column(
+          children: [
+            NakedDisclosure(child: Text('Closed'), panel: Text('Hidden')),
+            NakedDisclosure(
+              defaultExpanded: true,
+              child: Text('Open'),
+              panel: Text('Visible'),
+            ),
+          ],
+        ),
+      );
+
+      expect(find.text('Hidden'), findsNothing);
+      expect(find.text('Visible'), findsOneWidget);
+    });
+
+    testWidgets('ignores later defaultExpanded changes', (tester) async {
+      var defaultExpanded = false;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              defaultExpanded: defaultExpanded,
+              child: const Text('Trigger'),
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      rebuild(() => defaultExpanded = true);
+      await tester.pump();
+      expect(find.text('Panel'), findsNothing);
+    });
+
+    testWidgets('uncontrolled activation updates before notifying', (
+      tester,
+    ) async {
+      final requested = <bool>[];
+      late NakedDisclosureState state;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          onExpandedChanged: (value) {
+            requested.add(value);
+            expect(state.isExpanded, isFalse);
+          },
+          builder: (context, value, _) {
+            state = value;
+            return const Text('Trigger');
+          },
+          panel: const Text('Panel'),
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(requested, [true]);
+      expect(state.isExpanded, isTrue);
+      expect(find.text('Panel'), findsOneWidget);
+    });
+
+    testWidgets('uncontrolled disclosure toggles without callback', (
+      tester,
+    ) async {
+      await tester.pumpMaterialWidget(
+        const NakedDisclosure(child: Text('Trigger'), panel: Text('Panel')),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsNothing);
+    });
+
+    testWidgets('controlled requests can be rejected or accepted by owner', (
+      tester,
+    ) async {
+      var expanded = false;
+      final requests = <bool>[];
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              expanded: expanded,
+              onExpandedChanged: requests.add,
+              child: const Text('Trigger'),
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(requests, [true]);
+      expect(find.text('Panel'), findsNothing);
+
+      rebuild(() => expanded = true);
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+    });
+
+    testWidgets('controlled to uncontrolled preserves last accepted value', (
+      tester,
+    ) async {
+      bool? expanded = true;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              expanded: expanded,
+              onExpandedChanged: (_) {},
+              child: const Text('Trigger'),
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      rebuild(() => expanded = null);
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsNothing);
+    });
+
+    testWidgets('controlled disclosure without callback is read-only', (
+      tester,
+    ) async {
+      late NakedDisclosureState state;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          expanded: true,
+          builder: (_, value, _) {
+            state = value;
+            return const Text('Trigger');
+          },
+          panel: const Text('Panel'),
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(state.isDisabled, isTrue);
+      expect(state.isExpanded, isTrue);
+      expect(find.text('Panel'), findsOneWidget);
+    });
+  });
+
+  group('interaction and shared state', () {
+    testWidgets('activates with pointer, Enter, Space, and numpad Enter', (
+      tester,
+    ) async {
+      var expanded = false;
+      final requested = <bool>[];
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              autofocus: true,
+              expanded: expanded,
+              onExpandedChanged: (value) {
+                requested.add(value);
+                rebuild(() => expanded = value);
+              },
+              child: const Text('Trigger'),
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.numpadEnter);
+      await tester.pump();
+      expect(requested, [true, false, true, false]);
+    });
+
+    testWidgets('semantic activation toggles and keyboard focus is retained', (
+      tester,
+    ) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final semantics = tester.ensureSemantics();
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          focusNode: focusNode,
+          child: const Text('Trigger'),
+          panel: const Text('Panel'),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+      final triggerSemantics = tester.getSemantics(find.text('Trigger'));
+      triggerSemantics.owner!.performAction(
+        triggerSemantics.id,
+        SemanticsAction.tap,
+      );
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+      expect(focusNode.hasFocus, isTrue);
+      semantics.dispose();
+    });
+
+    testWidgets('keyboard press feedback lasts 100ms', (tester) async {
+      late NakedDisclosureState state;
+      final changes = <bool>[];
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          autofocus: true,
+          onPressChange: changes.add,
+          builder: (_, value, _) {
+            state = value;
+            return const Text('Trigger');
+          },
+          panel: const Text('Panel'),
+        ),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      expect(state.isPressed, isTrue);
+      await tester.pump(const Duration(milliseconds: 99));
+      expect(state.isPressed, isTrue);
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(state.isPressed, isFalse);
+      expect(changes, [true, false]);
+    });
+
+    testWidgets('becoming read-only clears an active keyboard press', (
+      tester,
+    ) async {
+      ValueChanged<bool>? callback = (_) {};
+      late StateSetter rebuild;
+      late NakedDisclosureState state;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              autofocus: true,
+              expanded: false,
+              onExpandedChanged: callback,
+              builder: (_, value, _) {
+                state = value;
+                return const Text('Trigger');
+              },
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      expect(state.isPressed, isTrue);
+      rebuild(() => callback = null);
+      await tester.pump();
+      expect(state.isPressed, isFalse);
+      expect(state.isDisabled, isTrue);
+      await tester.pump(const Duration(milliseconds: 150));
+      expect(state.isPressed, isFalse);
+    });
+
+    testWidgets('replaces focus nodes while preserving focus', (tester) async {
+      final first = FocusNode();
+      final second = FocusNode();
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      var node = first;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              focusNode: node,
+              child: const Text('Trigger'),
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      first.requestFocus();
+      await tester.pump();
+      rebuild(() => node = second);
+      await tester.pump();
+      await tester.pump();
+      expect(second.hasFocus, isTrue);
+    });
+
+    testWidgets('shares state and controller through every builder', (
+      tester,
+    ) async {
+      final states = <NakedDisclosureState>[];
+      final controllers = <WidgetStatesController>[];
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          defaultExpanded: true,
+          child: const Text('Static'),
+          builder: (context, state, child) {
+            states.add(state);
+            controllers.add(NakedDisclosureState.controllerOf(context));
+            return child!;
+          },
+          panel: Builder(
+            builder: (context) {
+              states.add(NakedDisclosureState.of(context));
+              controllers.add(NakedDisclosureState.controllerOf(context));
+              return const Text('Panel');
+            },
+          ),
+          transitionBuilder: (context, animation, child) {
+            states.add(NakedDisclosureState.of(context));
+            controllers.add(NakedDisclosureState.controllerOf(context));
+            return child;
+          },
+          itemBuilder: (context, state, child) {
+            states.add(state);
+            controllers.add(NakedDisclosureState.controllerOf(context));
+            return child!;
+          },
+        ),
+      );
+
+      expect(states, hasLength(4));
+      expect(states.every((state) => identical(state, states.first)), isTrue);
+      expect(
+        controllers.every(
+          (controller) => identical(controller, controllers.first),
+        ),
+        isTrue,
+      );
+      expect(states.first.isSelected, isTrue);
+    });
+
+    testWidgets('semantic exclusion preserves panel and controller identity', (
+      tester,
+    ) async {
+      var excludeSemantics = false;
+      var initializations = 0;
+      var disposals = 0;
+      WidgetStatesController? controller;
+      late WidgetStatesController latestController;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              defaultExpanded: true,
+              excludeSemantics: excludeSemantics,
+              builder: (context, state, child) {
+                latestController = NakedDisclosureState.controllerOf(context);
+                controller ??= latestController;
+                return child!;
+              },
+              child: const Text('Trigger'),
+              panel: _PanelLifecycleProbe(
+                onInitialized: () => initializations++,
+                onDisposed: () => disposals++,
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Panel 0'));
+      await tester.pump();
+      expect(find.text('Panel 1'), findsOneWidget);
+
+      rebuild(() => excludeSemantics = true);
+      await tester.pump();
+      expect(find.text('Panel 1'), findsOneWidget);
+      expect(identical(latestController, controller), isTrue);
+      expect(initializations, 1);
+      expect(disposals, 0);
+
+      rebuild(() => excludeSemantics = false);
+      await tester.pump();
+      expect(find.text('Panel 1'), findsOneWidget);
+      expect(identical(latestController, controller), isTrue);
+      expect(initializations, 1);
+      expect(disposals, 0);
+    });
+
+    testWidgets('reports hover, focus, press, selected, and disabled states', (
+      tester,
+    ) async {
+      const key = Key('disclosure');
+      late NakedDisclosureState state;
+      var enabled = true;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              key: key,
+              enabled: enabled,
+              builder: (_, value, _) {
+                state = value;
+                return const SizedBox(width: 100, height: 40);
+              },
+              panel: const Text('Panel'),
+            );
+          },
+        ),
+      );
+
+      await tester.simulateHover(
+        key,
+        onHover: () => expect(state.isHovered, isTrue),
+      );
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(key)),
+      );
+      await tester.pump();
+      expect(state.isPressed, isTrue);
+      await gesture.up();
+      await tester.pump();
+      expect(state.isSelected, isTrue);
+
+      rebuild(() => enabled = false);
+      await tester.pump();
+      expect(state.isDisabled, isTrue);
+    });
+
+    testWidgets('panel controls do not toggle the disclosure', (tester) async {
+      var panelPresses = 0;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          defaultExpanded: true,
+          child: const Text('Trigger'),
+          panel: TextButton(
+            onPressed: () => panelPresses++,
+            child: const Text('Panel action'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Panel action'));
+      await tester.pump();
+      expect(panelPresses, 1);
+      expect(find.text('Panel action'), findsOneWidget);
+    });
+
+    testWidgets(
+      'expanded panel participates in traversal and closing excludes it',
+      (tester) async {
+        final triggerFocus = FocusNode();
+        final firstPanelFocus = FocusNode();
+        final secondPanelFocus = FocusNode();
+        final afterFocus = FocusNode();
+        addTearDown(triggerFocus.dispose);
+        addTearDown(firstPanelFocus.dispose);
+        addTearDown(secondPanelFocus.dispose);
+        addTearDown(afterFocus.dispose);
+        var expanded = true;
+        var panelPresses = 0;
+        late StateSetter rebuild;
+        await tester.pumpMaterialWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              rebuild = setState;
+              return Column(
+                children: [
+                  NakedDisclosure(
+                    expanded: expanded,
+                    onExpandedChanged: (_) {},
+                    focusNode: triggerFocus,
+                    child: const Text('Trigger'),
+                    panel: Column(
+                      children: [
+                        TextButton(
+                          focusNode: firstPanelFocus,
+                          onPressed: () => panelPresses++,
+                          child: const Text('Panel action 1'),
+                        ),
+                        TextButton(
+                          focusNode: secondPanelFocus,
+                          onPressed: () => panelPresses++,
+                          child: const Text('Panel action 2'),
+                        ),
+                      ],
+                    ),
+                    transitionBuilder: (context, animation, child) =>
+                        FadeTransition(opacity: animation, child: child),
+                  ),
+                  TextButton(
+                    focusNode: afterFocus,
+                    onPressed: () {},
+                    child: const Text('After'),
+                  ),
+                ],
+              );
+            },
+          ),
+        );
+
+        triggerFocus.requestFocus();
+        await tester.pump();
+        triggerFocus.nextFocus();
+        await tester.pump();
+        expect(firstPanelFocus.hasFocus, isTrue);
+
+        firstPanelFocus.nextFocus();
+        await tester.pump();
+        expect(secondPanelFocus.hasFocus, isTrue);
+
+        secondPanelFocus.nextFocus();
+        await tester.pump();
+        expect(afterFocus.hasFocus, isTrue);
+
+        secondPanelFocus.requestFocus();
+        await tester.pump();
+        rebuild(() => expanded = false);
+        await tester.pump();
+        expect(secondPanelFocus.hasFocus, isFalse);
+        expect(triggerFocus.hasFocus, isTrue);
+        expect(find.text('Panel action 1'), findsOneWidget);
+        await tester.tap(find.text('Panel action 1'), warnIfMissed: false);
+        await tester.pump();
+        expect(panelPresses, 0);
+      },
+    );
+  });
+
+  group('panel lifecycle', () {
+    testWidgets('mounts and unmounts immediately without transition', (
+      tester,
+    ) async {
+      await tester.pumpMaterialWidget(
+        const NakedDisclosure(child: Text('Trigger'), panel: Text('Panel')),
+      );
+      expect(find.text('Panel'), findsNothing);
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsNothing);
+    });
+
+    testWidgets('retains exit content, excludes it, then removes it', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      bool panelIsAccessible() => tester.semantics
+          .simulatedAccessibilityTraversal()
+          .any((node) => node.getSemanticsData().label == 'Panel');
+      late Animation<double> animation;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          defaultExpanded: true,
+          child: const Text('Trigger'),
+          panel: const Text('Panel'),
+          transitionBuilder: (context, value, child) {
+            animation = value;
+            return FadeTransition(opacity: value, child: child);
+          },
+        ),
+      );
+      expect(animation.value, 1);
+      expect(panelIsAccessible(), isTrue);
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+      expect(panelIsAccessible(), isFalse);
+      expect(animation.value, 1);
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(animation.value, inExclusiveRange(0, 1));
+      await tester.pumpAndSettle();
+      expect(find.text('Panel'), findsNothing);
+      semantics.dispose();
+    });
+
+    testWidgets('mounts before forwarding and supports rapid reversal', (
+      tester,
+    ) async {
+      late Animation<double> animation;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          child: const Text('Trigger'),
+          panel: const Text('Panel'),
+          transitionBuilder: (context, value, child) {
+            animation = value;
+            return FadeTransition(opacity: value, child: child);
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      expect(find.text('Panel'), findsOneWidget);
+      expect(animation.value, 0);
+      await tester.pump(const Duration(milliseconds: 80));
+      await tester.tap(find.text('Trigger'));
+      await tester.pump(const Duration(milliseconds: 40));
+      await tester.tap(find.text('Trigger'));
+      await tester.pumpAndSettle();
+      expect(find.text('Panel'), findsOneWidget);
+      expect(animation.value, 1);
+    });
+
+    testWidgets('retains stateful panel identity through close and reversal', (
+      tester,
+    ) async {
+      var initializations = 0;
+      var disposals = 0;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          defaultExpanded: true,
+          child: const Text('Trigger'),
+          panel: _PanelLifecycleProbe(
+            onInitialized: () => initializations++,
+            onDisposed: () => disposals++,
+          ),
+          transitionBuilder: (context, animation, child) =>
+              FadeTransition(opacity: animation, child: child),
+        ),
+      );
+
+      expect(initializations, 1);
+      await tester.tap(find.text('Panel 0'));
+      await tester.pump();
+      expect(find.text('Panel 1'), findsOneWidget);
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump(const Duration(milliseconds: 80));
+      await tester.tap(find.text('Trigger'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Panel 1'), findsOneWidget);
+      expect(initializations, 1);
+      expect(disposals, 0);
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pumpAndSettle();
+      expect(find.text('Panel 1'), findsNothing);
+      expect(disposals, 1);
+    });
+
+    testWidgets('updates animation timing while open', (tester) async {
+      var style = const AnimationStyle(
+        curve: Curves.linear,
+        duration: Duration(milliseconds: 400),
+        reverseDuration: Duration(milliseconds: 400),
+      );
+      late Animation<double> animation;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return NakedDisclosure(
+              child: const Text('Trigger'),
+              panel: const Text('Panel'),
+              animationStyle: style,
+              transitionBuilder: (context, value, child) {
+                animation = value;
+                return FadeTransition(opacity: value, child: child);
+              },
+            );
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(animation.value, closeTo(0.25, 0.05));
+      rebuild(
+        () => style = const AnimationStyle(
+          curve: Curves.linear,
+          duration: Duration(milliseconds: 100),
+          reverseDuration: Duration(milliseconds: 100),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(animation.value, 1);
+    });
+
+    testWidgets('noAnimation and reduced motion snap panel lifecycle', (
+      tester,
+    ) async {
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          animationStyle: AnimationStyle.noAnimation,
+          child: const Text('No animation'),
+          panel: const Text('First panel'),
+          transitionBuilder: (context, animation, child) => child,
+        ),
+      );
+      await tester.tap(find.text('No animation'));
+      await tester.pump();
+      expect(find.text('First panel'), findsOneWidget);
+      await tester.tap(find.text('No animation'));
+      await tester.pump();
+      expect(find.text('First panel'), findsNothing);
+
+      await tester.pumpMaterialWidget(
+        MediaQuery(
+          data: const MediaQueryData(disableAnimations: true),
+          child: NakedDisclosure(
+            child: const Text('Reduced motion'),
+            panel: const Text('Second panel'),
+            transitionBuilder: (context, animation, child) => child,
+          ),
+        ),
+      );
+      await tester.tap(find.text('Reduced motion'));
+      await tester.pump();
+      expect(find.text('Second panel'), findsOneWidget);
+      await tester.tap(find.text('Reduced motion'));
+      await tester.pump();
+      expect(find.text('Second panel'), findsNothing);
+    });
+
+    testWidgets('can dispose during an active transition', (tester) async {
+      var show = true;
+      late StateSetter rebuild;
+      await tester.pumpMaterialWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return show
+                ? NakedDisclosure(
+                    child: const Text('Trigger'),
+                    panel: const Text('Panel'),
+                    transitionBuilder: (context, animation, child) =>
+                        FadeTransition(opacity: animation, child: child),
+                  )
+                : const SizedBox();
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump(const Duration(milliseconds: 50));
+      rebuild(() => show = false);
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
+  });
+}
+
+class _PanelLifecycleProbe extends StatefulWidget {
+  const _PanelLifecycleProbe({
+    required this.onInitialized,
+    required this.onDisposed,
+  });
+
+  final VoidCallback onInitialized;
+  final VoidCallback onDisposed;
+
+  @override
+  State<_PanelLifecycleProbe> createState() => _PanelLifecycleProbeState();
+}
+
+class _PanelLifecycleProbeState extends State<_PanelLifecycleProbe> {
+  var _value = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onInitialized();
+  }
+
+  @override
+  void dispose() {
+    widget.onDisposed();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () => setState(() => _value++),
+      child: Text('Panel $_value'),
+    );
+  }
+}


### PR DESCRIPTION
## Description

Adds `NakedDisclosure`, a standalone headless button-and-panel primitive for one independently expandable section.

Remix currently carries this generic behavior in a private `_NakedDisclosure`: controlled/uncontrolled expansion, selected widget state, button/expanded semantics, focus/hover/press state, and exit-aware panel animation. Moving that behavior into Naked UI avoids a downstream clone and makes it reusable without forcing consumers through accordion group machinery.

`NakedAccordion` is intentionally unchanged. A single disclosure does not need an accordion controller, keyed value, or min/max group constraints, so this PR stays additive and keeps the accordion blast radius at zero.

This PR includes:

- controlled and uncontrolled state with read-only controlled behavior
- pointer, Enter, Space, numpad Enter, focus, hover, press, and semantic activation
- one authoritative `NakedDisclosureState` and stable `WidgetStatesController`
- optional exit-aware transitions with reduced-motion support and inert closing content
- stable panel identity through close/reopen reversals and runtime semantics exclusion
- accessible expanded state, visible-label fallback, explicit label/hint replacement, and full exclusion
- a runnable controlled/uncontrolled example, public export, documentation, navigation, and README updates
- focused widget, lifecycle, traversal, semantics, and equality-contract coverage

Two independent pre-PR reviews were completed. Their confirmed findings were addressed by strengthening two-control panel traversal coverage and keeping the top-level semantics wrapper stable when `excludeSemantics` changes.

Screenshots are not applicable: this is a headless behavior primitive with no package-owned visual styling. The registered example demonstrates one possible presentation.

## Related Issues

Related to #46.

## Validation

- `fvm dart run melos run format:check`
- `fvm flutter analyze`
- `fvm flutter test packages/naked_ui/test` — 744 passed, 3 expected skips
- `fvm flutter test packages/example/test` — 26 passed, 3 expected golden skips
- `fvm flutter pub publish --dry-run --directory packages/naked_ui` — 0 warnings
- `git diff --check`
- `jq empty docs.json`

## Follow-up

After a release containing `NakedDisclosure`, Remix can replace its private behavior bridge while retaining Remix-owned styling, motion, and public API in a separate downstream PR.

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
