### PR TITLE
chore(release): prepare 1.0.0-beta.13

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-beta.13
+
+### Features
+
+- Add `NakedDisclosure`, a standalone headless button-and-panel primitive with
+  controlled and uncontrolled state, accessible expanded semantics, shared
+  widget state, normal panel focus traversal, and optional exit-aware
+  transitions that preserve panel state while closing.
+
 ## 1.0.0-beta.12
 
 ### Features

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.12
+version: 1.0.0-beta.13
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## What

Cuts `1.0.0-beta.13`: adds the release changelog section and bumps `packages/naked_ui/pubspec.yaml`.

## Contents

One feature PR landed since `1.0.0-beta.12`:

- #95 — adds the standalone `NakedDisclosure` primitive with controlled and uncontrolled state, accessible expanded semantics, normal focus traversal, preserved panel state during exit transitions, documentation, and examples.

## Verification

- `fvm dart run melos run format:check`
- `fvm flutter analyze`
- Package tests: 744 passed, 3 expected skips
- Example tests: 26 passed, 3 expected skips
- `fvm flutter pub publish --dry-run --directory packages/naked_ui`: 0 warnings

## After merge

Publishing is tag-driven. Tag the merged `main` commit as `v1.0.0-beta.13` to trigger the release workflow and pub.dev publication.
