### PR TITLE
fix: expose disclosure trigger-to-panel semantics relationship

### DIFF
--- a/.github/workflows/integration-web.yml
+++ b/.github/workflows/integration-web.yml
@@ -68,12 +68,23 @@ jobs:
             --browser-dimension=800x600@1 \
             --chrome-binary="${{ steps.chrome.outputs.chrome-path }}" \
             2>&1 | tee build/web-integration.log
+          flutter drive \
+            --driver=test_driver/integration_test_behavior.dart \
+            --target=integration_test/web_disclosure_semantics.dart \
+            -d web-server \
+            --browser-name=chrome \
+            --browser-dimension=800x600@1 \
+            --chrome-binary="${{ steps.chrome.outputs.chrome-path }}" \
+            2>&1 | tee build/web-semantics-integration.log
 
       - name: Verify web integration evidence
         run: |
           log=packages/example/build/web-integration.log
           grep -F "All tests passed." "$log"
-          if grep -Eq 'TimeoutException|Some tests failed\.| \[E\]' "$log"; then
+          semantics_log=packages/example/build/web-semantics-integration.log
+          grep -F "All tests passed." "$semantics_log"
+          if grep -Eq 'TimeoutException|Some tests failed\.| \[E\]' \
+            "$log" "$semantics_log"; then
             echo "The in-app test runner reported failures." >&2
             exit 1
           fi
@@ -85,6 +96,7 @@ jobs:
           name: integration-web-${{ github.sha }}
           path: |
             packages/example/build/web-integration.log
+            packages/example/build/web-semantics-integration.log
             packages/example/build/integration_response_data.json
           if-no-files-found: warn
           retention-days: 14

--- a/docs/widget/disclosure.mdx
+++ b/docs/widget/disclosure.mdx
@@ -123,8 +123,10 @@ reopened panel.
 
 - The trigger is the only button and the only disclosure tap target.
 - Visible trigger text supplies the accessible name by default.
-- While expanded, the trigger identifies the panel it controls. The relationship
-  is removed while collapsed because the panel is absent from the semantics tree.
+- While expanded, the trigger identifies a distinct panel semantics container it
+  controls. Flutter web maps this relationship to `aria-controls`.
+- The relationship is removed while collapsed because the panel is absent from
+  the semantics tree.
 - A non-empty `semanticLabel` replaces trigger-descendant semantics; use
   `semanticHint` for short additional context.
 - `excludeSemantics: true` hides both the trigger and panel.

--- a/docs/widget/disclosure.mdx
+++ b/docs/widget/disclosure.mdx
@@ -123,6 +123,8 @@ reopened panel.
 
 - The trigger is the only button and the only disclosure tap target.
 - Visible trigger text supplies the accessible name by default.
+- While expanded, the trigger identifies the panel it controls. The relationship
+  is removed while collapsed because the panel is absent from the semantics tree.
 - A non-empty `semanticLabel` replaces trigger-descendant semantics; use
   `semanticHint` for short additional context.
 - `excludeSemantics: true` hides both the trigger and panel.

--- a/packages/example/integration_test/web_disclosure_semantics.dart
+++ b/packages/example/integration_test/web_disclosure_semantics.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('disclosure controls each remounted web semantics panel', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: NakedDisclosure(
+              autofocus: true,
+              defaultExpanded: true,
+              semanticLabel: 'Disclosure trigger',
+              panel: Text('Panel'),
+              child: Text('Trigger'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final panelIds = <String>{};
+    final panelIdentifiers = <String>{};
+
+    void expectExpandedRelationship() {
+      final trigger = web.document.querySelector(
+        '[role="button"][aria-expanded]',
+      );
+      expect(trigger, isNotNull);
+      expect(trigger!.getAttribute('aria-expanded'), 'true');
+
+      final controls = trigger.getAttribute('aria-controls');
+      expect(controls, isNotNull);
+      final panel = web.document.getElementById(controls!);
+      expect(panel, isNotNull);
+      expect(
+        panel!.getAttribute('flt-semantics-identifier'),
+        startsWith('naked-disclosure-panel-'),
+      );
+      expect(panel.textContent, contains('Panel'));
+      panelIds.add(panel.id);
+      panelIdentifiers.add(panel.getAttribute('flt-semantics-identifier')!);
+    }
+
+    void expectCollapsedRelationship() {
+      final trigger = web.document.querySelector(
+        '[role="button"][aria-expanded]',
+      );
+      expect(trigger, isNotNull);
+      expect(trigger!.getAttribute('aria-expanded'), 'false');
+      expect(trigger.getAttribute('aria-controls'), isNull);
+      expect(
+        web.document.querySelector(
+          '[flt-semantics-identifier^="naked-disclosure-panel-"]',
+        ),
+        isNull,
+      );
+    }
+
+    expectExpandedRelationship();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expectCollapsedRelationship();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expectExpandedRelationship();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expectCollapsedRelationship();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expectExpandedRelationship();
+
+    expect(panelIds, hasLength(3));
+    expect(panelIdentifiers, hasLength(3));
+    semantics.dispose();
+  });
+}

--- a/packages/example/pubspec.yaml
+++ b/packages/example/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+  web: ^1.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -181,8 +181,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   static int _nextPanelSemanticsIdentifier = 0;
 
   Timer? _keyboardPressTimer;
-  late final String _panelSemanticsIdentifier =
-      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
+  late String _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
   final FocusNode _panelFocusNode = FocusNode(
     debugLabel: 'NakedDisclosure panel',
   );
@@ -204,6 +203,11 @@ class _NakedDisclosureState extends State<NakedDisclosure>
       widget.transitionBuilder != null &&
       widget.animationStyle != AnimationStyle.noAnimation &&
       !_animationsDisabled;
+
+  // A remounted panel gets a new semantics node. Refreshing the identifier
+  // forces platforms to resolve controlsNodes to that new node.
+  static String _newPanelSemanticsIdentifier() =>
+      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
 
   Duration get _forwardDuration =>
       widget.animationStyle.duration ?? const Duration(milliseconds: 200);
@@ -287,6 +291,9 @@ class _NakedDisclosureState extends State<NakedDisclosure>
     }
 
     updateSelectedState(_isExpanded, null);
+    if (oldExpanded != _isExpanded && _isExpanded) {
+      _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
+    }
     if (oldExpanded != _isExpanded ||
         oldWidget.transitionBuilder != widget.transitionBuilder ||
         oldWidget.animationStyle != widget.animationStyle) {
@@ -305,6 +312,9 @@ class _NakedDisclosureState extends State<NakedDisclosure>
 
     if (!_isControlled) {
       _uncontrolledExpanded = nextExpanded;
+      if (nextExpanded) {
+        _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
+      }
       updateSelectedState(nextExpanded, null);
       _applyExpansion();
     }

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -178,7 +178,11 @@ class _NakedDisclosureState extends State<NakedDisclosure>
         WidgetStatesMixin<NakedDisclosure>,
         FocusNodeMixin<NakedDisclosure>,
         SingleTickerProviderStateMixin<NakedDisclosure> {
+  static int _nextPanelSemanticsIdentifier = 0;
+
   Timer? _keyboardPressTimer;
+  late final String _panelSemanticsIdentifier =
+      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
   final FocusNode _panelFocusNode = FocusNode(
     debugLabel: 'NakedDisclosure panel',
   );
@@ -365,12 +369,15 @@ class _NakedDisclosureState extends State<NakedDisclosure>
 
   Widget _buildPanel(BuildContext context) {
     final panelHidden = !_isExpanded;
-    final panel = Focus(
-      focusNode: _panelFocusNode,
-      canRequestFocus: false,
-      skipTraversal: true,
-      includeSemantics: false,
-      child: widget.panel,
+    final panel = Semantics(
+      identifier: _panelSemanticsIdentifier,
+      child: Focus(
+        focusNode: _panelFocusNode,
+        canRequestFocus: false,
+        skipTraversal: true,
+        includeSemantics: false,
+        child: widget.panel,
+      ),
     );
     final transitionBuilder = widget.transitionBuilder;
     final transitionedPanel = transitionBuilder == null
@@ -434,6 +441,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
             enabled: _isInteractive,
             button: true,
             expanded: _isExpanded,
+            controlsNodes: _isExpanded ? {_panelSemanticsIdentifier} : null,
             label: hasReplacementLabel ? semanticLabel : null,
             hint: widget.semanticHint,
             excludeSemantics: hasReplacementLabel,

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/widgets.dart';
 
 import 'mixins/naked_mixins.dart';
@@ -182,7 +183,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
 
   Timer? _keyboardPressTimer;
   late String _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
-  final GlobalKey _triggerSubtreeKey = GlobalKey();
+  final GlobalKey? _webTriggerSubtreeKey = kIsWeb ? GlobalKey() : null;
   final FocusNode _panelFocusNode = FocusNode(
     debugLabel: 'NakedDisclosure panel',
   );
@@ -191,7 +192,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   late bool _uncontrolledExpanded;
   late bool _panelMounted;
   late bool _panelSemanticsReady;
-  int _triggerSemanticsGeneration = 0;
+  int _webTriggerSemanticsGeneration = 0;
   bool _animationsDisabled = false;
   int _transitionGeneration = 0;
 
@@ -323,13 +324,18 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   }
 
   void _refreshPanelSemanticsRelationship() {
+    if (!kIsWeb) {
+      _panelSemanticsReady = _isExpanded;
+      return;
+    }
+
     _panelSemanticsReady = false;
     if (!_isExpanded) return;
     _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
-    _schedulePanelSemanticsRelationship();
+    _scheduleWebPanelSemanticsRelationship();
   }
 
-  void _schedulePanelSemanticsRelationship() {
+  void _scheduleWebPanelSemanticsRelationship() {
     // Flutter web resolves controlsNodes to a DOM node ID when the semantics
     // update arrives, so wait until the remounted panel has registered itself.
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -337,7 +343,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
       setState(() {
         // Recreate the trigger semantics boundary because Flutter web does
         // not re-resolve controlsNodes there after its target remounts.
-        _triggerSemanticsGeneration += 1;
+        _webTriggerSemanticsGeneration += 1;
         _panelSemanticsReady = true;
       });
     });
@@ -471,7 +477,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
           );
 
           final focusableTrigger = NakedFocusableDetector(
-            key: _triggerSubtreeKey,
+            key: _webTriggerSubtreeKey,
             enabled: _isInteractive,
             autofocus: widget.autofocus,
             onFocusChange: (focused) =>
@@ -490,7 +496,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
           );
 
           final semanticTrigger = Semantics(
-            key: ValueKey(_triggerSemanticsGeneration),
+            key: kIsWeb ? ValueKey(_webTriggerSemanticsGeneration) : null,
             container: true,
             enabled: _isInteractive,
             button: true,

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -181,8 +181,8 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   static int _nextPanelSemanticsIdentifier = 0;
 
   Timer? _keyboardPressTimer;
-  late final String _panelSemanticsIdentifier =
-      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
+  late String _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
+  final GlobalKey _triggerSubtreeKey = GlobalKey();
   final FocusNode _panelFocusNode = FocusNode(
     debugLabel: 'NakedDisclosure panel',
   );
@@ -191,6 +191,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   late bool _uncontrolledExpanded;
   late bool _panelMounted;
   late bool _panelSemanticsReady;
+  int _triggerSemanticsGeneration = 0;
   bool _animationsDisabled = false;
   int _transitionGeneration = 0;
 
@@ -205,6 +206,9 @@ class _NakedDisclosureState extends State<NakedDisclosure>
       widget.transitionBuilder != null &&
       widget.animationStyle != AnimationStyle.noAnimation &&
       !_animationsDisabled;
+
+  static String _newPanelSemanticsIdentifier() =>
+      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
 
   Duration get _forwardDuration =>
       widget.animationStyle.duration ?? const Duration(milliseconds: 200);
@@ -290,8 +294,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
 
     updateSelectedState(_isExpanded, null);
     if (oldExpanded != _isExpanded) {
-      _panelSemanticsReady = false;
-      if (_isExpanded) _schedulePanelSemanticsRelationship();
+      _refreshPanelSemanticsRelationship();
     }
     if (oldExpanded != _isExpanded ||
         oldWidget.transitionBuilder != widget.transitionBuilder ||
@@ -311,8 +314,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
 
     if (!_isControlled) {
       _uncontrolledExpanded = nextExpanded;
-      _panelSemanticsReady = false;
-      if (nextExpanded) _schedulePanelSemanticsRelationship();
+      _refreshPanelSemanticsRelationship();
       updateSelectedState(nextExpanded, null);
       _applyExpansion();
     }
@@ -320,12 +322,24 @@ class _NakedDisclosureState extends State<NakedDisclosure>
     widget.onExpandedChanged?.call(nextExpanded);
   }
 
+  void _refreshPanelSemanticsRelationship() {
+    _panelSemanticsReady = false;
+    if (!_isExpanded) return;
+    _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
+    _schedulePanelSemanticsRelationship();
+  }
+
   void _schedulePanelSemanticsRelationship() {
     // Flutter web resolves controlsNodes to a DOM node ID when the semantics
     // update arrives, so wait until the remounted panel has registered itself.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !_isExpanded || _panelSemanticsReady) return;
-      setState(() => _panelSemanticsReady = true);
+      setState(() {
+        // Recreate the trigger semantics boundary because Flutter web does
+        // not re-resolve controlsNodes there after its target remounts.
+        _triggerSemanticsGeneration += 1;
+        _panelSemanticsReady = true;
+      });
     });
   }
 
@@ -456,21 +470,8 @@ class _NakedDisclosureState extends State<NakedDisclosure>
             child: trigger,
           );
 
-          final semanticTrigger = Semantics(
-            enabled: _isInteractive,
-            button: true,
-            expanded: _isExpanded,
-            controlsNodes: _isExpanded && _panelSemanticsReady
-                ? {_panelSemanticsIdentifier}
-                : null,
-            label: hasReplacementLabel ? semanticLabel : null,
-            hint: widget.semanticHint,
-            excludeSemantics: hasReplacementLabel,
-            onTap: _isInteractive ? _handleTap : null,
-            child: triggerContent,
-          );
-
           final focusableTrigger = NakedFocusableDetector(
+            key: _triggerSubtreeKey,
             enabled: _isInteractive,
             autofocus: widget.autofocus,
             onFocusChange: (focused) =>
@@ -485,10 +486,26 @@ class _NakedDisclosureState extends State<NakedDisclosure>
             actions: NakedIntentActions.button.actions(
               onPressed: _handleKeyboardActivation,
             ),
-            child: semanticTrigger,
+            child: triggerContent,
           );
 
-          final children = <Widget>[focusableTrigger];
+          final semanticTrigger = Semantics(
+            key: ValueKey(_triggerSemanticsGeneration),
+            container: true,
+            enabled: _isInteractive,
+            button: true,
+            expanded: _isExpanded,
+            controlsNodes: _isExpanded && _panelSemanticsReady
+                ? {_panelSemanticsIdentifier}
+                : null,
+            label: hasReplacementLabel ? semanticLabel : null,
+            hint: widget.semanticHint,
+            excludeSemantics: hasReplacementLabel,
+            onTap: _isInteractive ? _handleTap : null,
+            child: focusableTrigger,
+          );
+
+          final children = <Widget>[semanticTrigger];
           if (_panelMounted) children.add(_buildPanel(context));
           final assembledItem = Column(
             mainAxisSize: MainAxisSize.min,

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -370,6 +370,8 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   Widget _buildPanel(BuildContext context) {
     final panelHidden = !_isExpanded;
     final panel = Semantics(
+      container: true,
+      explicitChildNodes: true,
       identifier: _panelSemanticsIdentifier,
       child: Focus(
         focusNode: _panelFocusNode,

--- a/packages/naked_ui/lib/src/naked_disclosure.dart
+++ b/packages/naked_ui/lib/src/naked_disclosure.dart
@@ -181,7 +181,8 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   static int _nextPanelSemanticsIdentifier = 0;
 
   Timer? _keyboardPressTimer;
-  late String _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
+  late final String _panelSemanticsIdentifier =
+      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
   final FocusNode _panelFocusNode = FocusNode(
     debugLabel: 'NakedDisclosure panel',
   );
@@ -189,6 +190,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
   late CurvedAnimation _animation;
   late bool _uncontrolledExpanded;
   late bool _panelMounted;
+  late bool _panelSemanticsReady;
   bool _animationsDisabled = false;
   int _transitionGeneration = 0;
 
@@ -203,11 +205,6 @@ class _NakedDisclosureState extends State<NakedDisclosure>
       widget.transitionBuilder != null &&
       widget.animationStyle != AnimationStyle.noAnimation &&
       !_animationsDisabled;
-
-  // A remounted panel gets a new semantics node. Refreshing the identifier
-  // forces platforms to resolve controlsNodes to that new node.
-  static String _newPanelSemanticsIdentifier() =>
-      'naked-disclosure-panel-${_nextPanelSemanticsIdentifier++}';
 
   Duration get _forwardDuration =>
       widget.animationStyle.duration ?? const Duration(milliseconds: 200);
@@ -235,6 +232,7 @@ class _NakedDisclosureState extends State<NakedDisclosure>
     // WidgetStatesMixin initializes state from _isExpanded in super.initState.
     _uncontrolledExpanded = widget.defaultExpanded;
     _panelMounted = _isExpanded;
+    _panelSemanticsReady = _isExpanded;
     super.initState();
     _animationController = AnimationController(
       value: _isExpanded ? 1 : 0,
@@ -291,8 +289,9 @@ class _NakedDisclosureState extends State<NakedDisclosure>
     }
 
     updateSelectedState(_isExpanded, null);
-    if (oldExpanded != _isExpanded && _isExpanded) {
-      _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
+    if (oldExpanded != _isExpanded) {
+      _panelSemanticsReady = false;
+      if (_isExpanded) _schedulePanelSemanticsRelationship();
     }
     if (oldExpanded != _isExpanded ||
         oldWidget.transitionBuilder != widget.transitionBuilder ||
@@ -312,14 +311,22 @@ class _NakedDisclosureState extends State<NakedDisclosure>
 
     if (!_isControlled) {
       _uncontrolledExpanded = nextExpanded;
-      if (nextExpanded) {
-        _panelSemanticsIdentifier = _newPanelSemanticsIdentifier();
-      }
+      _panelSemanticsReady = false;
+      if (nextExpanded) _schedulePanelSemanticsRelationship();
       updateSelectedState(nextExpanded, null);
       _applyExpansion();
     }
 
     widget.onExpandedChanged?.call(nextExpanded);
+  }
+
+  void _schedulePanelSemanticsRelationship() {
+    // Flutter web resolves controlsNodes to a DOM node ID when the semantics
+    // update arrives, so wait until the remounted panel has registered itself.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_isExpanded || _panelSemanticsReady) return;
+      setState(() => _panelSemanticsReady = true);
+    });
   }
 
   void _handleTap() {
@@ -453,7 +460,9 @@ class _NakedDisclosureState extends State<NakedDisclosure>
             enabled: _isInteractive,
             button: true,
             expanded: _isExpanded,
-            controlsNodes: _isExpanded ? {_panelSemanticsIdentifier} : null,
+            controlsNodes: _isExpanded && _panelSemanticsReady
+                ? {_panelSemanticsIdentifier}
+                : null,
             label: hasReplacementLabel ? semanticLabel : null,
             hint: widget.semanticHint,
             excludeSemantics: hasReplacementLabel,

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -89,9 +89,65 @@ void main() {
         tester.getSemantics(find.byType(Scaffold)),
         reopenedPanelIdentifier,
       );
-      expect(reopenedPanelIdentifier, initialPanelIdentifier);
+      expect(reopenedPanelIdentifier, isNot(initialPanelIdentifier));
       expect(reopenedPanel.id, isNot(reopenedTrigger.id));
       expect(_subtreeContainsLabel(reopenedPanel, 'Panel'), isTrue);
+      handle.dispose();
+    });
+
+    testWidgets('refreshes the controlled panel target when remounted', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      var expanded = true;
+      late StateSetter rebuild;
+      await tester.pumpWidget(
+        buildApp(
+          StatefulBuilder(
+            builder: (context, setState) {
+              rebuild = setState;
+              return NakedDisclosure(
+                expanded: expanded,
+                onExpandedChanged: (_) {},
+                child: const Text('Controlled trigger'),
+                panel: const Text('Controlled panel'),
+              );
+            },
+          ),
+        ),
+      );
+
+      final initialIdentifier = _controlledIdentifier(
+        tester.getSemantics(find.text('Controlled trigger')),
+      );
+
+      rebuild(() => expanded = false);
+      await tester.pump();
+      expect(
+        tester
+            .getSemantics(find.text('Controlled trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        isNull,
+      );
+
+      rebuild(() => expanded = true);
+      await tester.pump();
+      final reopenedIdentifier = _controlledIdentifier(
+        tester.getSemantics(find.text('Controlled trigger')),
+      );
+
+      expect(reopenedIdentifier, isNot(initialIdentifier));
+      expect(
+        _subtreeContainsLabel(
+          _nodeWithIdentifier(
+            tester.getSemantics(find.byType(Scaffold)),
+            reopenedIdentifier,
+          ),
+          'Controlled panel',
+        ),
+        isTrue,
+      );
       handle.dispose();
     });
 

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -46,7 +46,9 @@ void main() {
   );
 
   group('NakedDisclosure semantics', () {
-    testWidgets('controls its panel only while expanded', (tester) async {
+    testWidgets('controls each remounted panel only after it is registered', (
+      tester,
+    ) async {
       final handle = tester.ensureSemantics();
       await tester.pumpWidget(
         buildApp(
@@ -98,75 +100,99 @@ void main() {
         tester.getSemantics(find.byType(Scaffold)),
         reopenedPanelIdentifier,
       );
-      expect(reopenedPanelIdentifier, initialPanelIdentifier);
+      expect(reopenedPanelIdentifier, isNot(initialPanelIdentifier));
       expect(reopenedPanel.id, isNot(reopenedTrigger.id));
       expect(_subtreeContainsLabel(reopenedPanel, 'Panel'), isTrue);
-      handle.dispose();
-    });
 
-    testWidgets('defers a controlled relationship until its target remounts', (
-      tester,
-    ) async {
-      final handle = tester.ensureSemantics();
-      var expanded = true;
-      late StateSetter rebuild;
-      await tester.pumpWidget(
-        buildApp(
-          StatefulBuilder(
-            builder: (context, setState) {
-              rebuild = setState;
-              return NakedDisclosure(
-                expanded: expanded,
-                onExpandedChanged: (_) {},
-                child: const Text('Controlled trigger'),
-                panel: const Text('Controlled panel'),
-              );
-            },
-          ),
-        ),
-      );
-
-      final initialIdentifier = _controlledIdentifier(
-        tester.getSemantics(find.text('Controlled trigger')),
-      );
-
-      rebuild(() => expanded = false);
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      await tester.tap(find.text('Trigger'));
       await tester.pump();
       expect(
         tester
-            .getSemantics(find.text('Controlled trigger'))
-            .getSemanticsData()
-            .controlsNodes,
-        isNull,
-      );
-
-      rebuild(() => expanded = true);
-      await tester.pump();
-      expect(
-        tester
-            .getSemantics(find.text('Controlled trigger'))
+            .getSemantics(find.text('Trigger'))
             .getSemanticsData()
             .controlsNodes,
         isNull,
       );
       await tester.pump();
-      final reopenedIdentifier = _controlledIdentifier(
-        tester.getSemantics(find.text('Controlled trigger')),
-      );
 
-      expect(reopenedIdentifier, initialIdentifier);
-      expect(
-        _subtreeContainsLabel(
-          _nodeWithIdentifier(
-            tester.getSemantics(find.byType(Scaffold)),
-            reopenedIdentifier,
-          ),
-          'Controlled panel',
-        ),
-        isTrue,
+      final secondReopenedTrigger = tester.getSemantics(find.text('Trigger'));
+      final secondReopenedIdentifier = _controlledIdentifier(
+        secondReopenedTrigger,
       );
+      final secondReopenedPanel = _nodeWithIdentifier(
+        tester.getSemantics(find.byType(Scaffold)),
+        secondReopenedIdentifier,
+      );
+      expect(secondReopenedIdentifier, isNot(reopenedPanelIdentifier));
+      expect(secondReopenedPanel.id, isNot(secondReopenedTrigger.id));
+      expect(_subtreeContainsLabel(secondReopenedPanel, 'Panel'), isTrue);
       handle.dispose();
     });
+
+    testWidgets(
+      'defers and refreshes a controlled relationship when its target remounts',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        var expanded = true;
+        late StateSetter rebuild;
+        await tester.pumpWidget(
+          buildApp(
+            StatefulBuilder(
+              builder: (context, setState) {
+                rebuild = setState;
+                return NakedDisclosure(
+                  expanded: expanded,
+                  onExpandedChanged: (_) {},
+                  child: const Text('Controlled trigger'),
+                  panel: const Text('Controlled panel'),
+                );
+              },
+            ),
+          ),
+        );
+
+        final initialIdentifier = _controlledIdentifier(
+          tester.getSemantics(find.text('Controlled trigger')),
+        );
+
+        rebuild(() => expanded = false);
+        await tester.pump();
+        expect(
+          tester
+              .getSemantics(find.text('Controlled trigger'))
+              .getSemanticsData()
+              .controlsNodes,
+          isNull,
+        );
+
+        rebuild(() => expanded = true);
+        await tester.pump();
+        expect(
+          tester
+              .getSemantics(find.text('Controlled trigger'))
+              .getSemanticsData()
+              .controlsNodes,
+          isNull,
+        );
+        await tester.pump();
+        final reopenedIdentifier = _controlledIdentifier(
+          tester.getSemantics(find.text('Controlled trigger')),
+        );
+
+        expect(reopenedIdentifier, isNot(initialIdentifier));
+        final reopenedPanel = _nodeWithIdentifier(
+          tester.getSemantics(find.byType(Scaffold)),
+          reopenedIdentifier,
+        );
+        expect(
+          _subtreeContainsLabel(reopenedPanel, 'Controlled panel'),
+          isTrue,
+        );
+        handle.dispose();
+      },
+    );
 
     testWidgets('uses unique panel identifiers for multiple disclosures', (
       tester,

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -18,6 +18,109 @@ void main() {
   );
 
   group('NakedDisclosure semantics', () {
+    testWidgets('controls its panel only while expanded', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          const NakedDisclosure(
+            defaultExpanded: true,
+            child: Text('Trigger'),
+            panel: Text('Panel'),
+          ),
+        ),
+      );
+
+      final expandedTrigger = tester
+          .getSemantics(find.text('Trigger'))
+          .getSemanticsData();
+      final initialPanelIdentifier = tester
+          .getSemantics(find.text('Panel'))
+          .getSemanticsData()
+          .identifier;
+      expect(initialPanelIdentifier, isNotEmpty);
+      expect(expandedTrigger.controlsNodes, {initialPanelIdentifier});
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+
+      expect(
+        tester
+            .getSemantics(find.text('Trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        isNull,
+      );
+      expect(find.text('Panel'), findsNothing);
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+
+      final reopenedPanelIdentifier = tester
+          .getSemantics(find.text('Panel'))
+          .getSemanticsData()
+          .identifier;
+      expect(reopenedPanelIdentifier, initialPanelIdentifier);
+      expect(
+        tester
+            .getSemantics(find.text('Trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        {reopenedPanelIdentifier},
+      );
+      handle.dispose();
+    });
+
+    testWidgets('uses unique panel identifiers for multiple disclosures', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          const Column(
+            children: [
+              NakedDisclosure(
+                defaultExpanded: true,
+                child: Text('First trigger'),
+                panel: Text('First panel'),
+              ),
+              NakedDisclosure(
+                defaultExpanded: true,
+                child: Text('Second trigger'),
+                panel: Text('Second panel'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final firstPanelIdentifier = tester
+          .getSemantics(find.text('First panel'))
+          .getSemanticsData()
+          .identifier;
+      final secondPanelIdentifier = tester
+          .getSemantics(find.text('Second panel'))
+          .getSemanticsData()
+          .identifier;
+      expect(firstPanelIdentifier, isNotEmpty);
+      expect(secondPanelIdentifier, isNotEmpty);
+      expect(firstPanelIdentifier, isNot(secondPanelIdentifier));
+      expect(
+        tester
+            .getSemantics(find.text('First trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        {firstPanelIdentifier},
+      );
+      expect(
+        tester
+            .getSemantics(find.text('Second trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        {secondPanelIdentifier},
+      );
+      handle.dispose();
+    });
+
     testWidgets('exposes one named button with enabled and expanded flags', (
       tester,
     ) async {

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -83,19 +83,28 @@ void main() {
       await tester.tap(find.text('Trigger'));
       await tester.pump();
 
+      expect(
+        tester
+            .getSemantics(find.text('Trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        isNull,
+      );
+      await tester.pump();
+
       final reopenedTrigger = tester.getSemantics(find.text('Trigger'));
       final reopenedPanelIdentifier = _controlledIdentifier(reopenedTrigger);
       final reopenedPanel = _nodeWithIdentifier(
         tester.getSemantics(find.byType(Scaffold)),
         reopenedPanelIdentifier,
       );
-      expect(reopenedPanelIdentifier, isNot(initialPanelIdentifier));
+      expect(reopenedPanelIdentifier, initialPanelIdentifier);
       expect(reopenedPanel.id, isNot(reopenedTrigger.id));
       expect(_subtreeContainsLabel(reopenedPanel, 'Panel'), isTrue);
       handle.dispose();
     });
 
-    testWidgets('refreshes the controlled panel target when remounted', (
+    testWidgets('defers a controlled relationship until its target remounts', (
       tester,
     ) async {
       final handle = tester.ensureSemantics();
@@ -133,11 +142,19 @@ void main() {
 
       rebuild(() => expanded = true);
       await tester.pump();
+      expect(
+        tester
+            .getSemantics(find.text('Controlled trigger'))
+            .getSemanticsData()
+            .controlsNodes,
+        isNull,
+      );
+      await tester.pump();
       final reopenedIdentifier = _controlledIdentifier(
         tester.getSemantics(find.text('Controlled trigger')),
       );
 
-      expect(reopenedIdentifier, isNot(initialIdentifier));
+      expect(reopenedIdentifier, initialIdentifier);
       expect(
         _subtreeContainsLabel(
           _nodeWithIdentifier(

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' show Tristate;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -46,93 +47,81 @@ void main() {
   );
 
   group('NakedDisclosure semantics', () {
-    testWidgets('controls each remounted panel only after it is registered', (
-      tester,
-    ) async {
-      final handle = tester.ensureSemantics();
-      await tester.pumpWidget(
-        buildApp(
-          const NakedDisclosure(
-            defaultExpanded: true,
-            child: Text('Trigger'),
-            panel: Text('Panel'),
+    testWidgets(
+      'keeps native semantics identity stable across panel remounts',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildApp(
+            const NakedDisclosure(
+              defaultExpanded: true,
+              child: Text('Trigger'),
+              panel: Text('Panel'),
+            ),
           ),
-        ),
-      );
+        );
 
-      final expandedTrigger = tester.getSemantics(find.text('Trigger'));
-      final initialPanelIdentifier = _controlledIdentifier(expandedTrigger);
-      final initialPanel = _nodeWithIdentifier(
-        tester.getSemantics(find.byType(Scaffold)),
-        initialPanelIdentifier,
-      );
-      expect(initialPanelIdentifier, isNotEmpty);
-      expect(initialPanel.id, isNot(expandedTrigger.id));
-      expect(_subtreeContainsLabel(initialPanel, 'Panel'), isTrue);
+        final expandedTrigger = tester.getSemantics(find.text('Trigger'));
+        final initialTriggerId = expandedTrigger.id;
+        final initialPanelIdentifier = _controlledIdentifier(expandedTrigger);
+        final initialPanel = _nodeWithIdentifier(
+          tester.getSemantics(find.byType(Scaffold)),
+          initialPanelIdentifier,
+        );
+        expect(initialPanelIdentifier, isNotEmpty);
+        expect(initialPanel.id, isNot(expandedTrigger.id));
+        expect(_subtreeContainsLabel(initialPanel, 'Panel'), isTrue);
 
-      await tester.tap(find.text('Trigger'));
-      await tester.pump();
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
 
-      expect(
-        tester
-            .getSemantics(find.text('Trigger'))
-            .getSemanticsData()
-            .controlsNodes,
-        isNull,
-      );
-      expect(find.text('Panel'), findsNothing);
+        expect(
+          tester
+              .getSemantics(find.text('Trigger'))
+              .getSemanticsData()
+              .controlsNodes,
+          isNull,
+        );
+        expect(find.text('Panel'), findsNothing);
 
-      await tester.tap(find.text('Trigger'));
-      await tester.pump();
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
 
-      expect(
-        tester
-            .getSemantics(find.text('Trigger'))
-            .getSemanticsData()
-            .controlsNodes,
-        isNull,
-      );
-      await tester.pump();
+        final reopenedTrigger = tester.getSemantics(find.text('Trigger'));
+        final reopenedPanelIdentifier = _controlledIdentifier(reopenedTrigger);
+        final reopenedPanel = _nodeWithIdentifier(
+          tester.getSemantics(find.byType(Scaffold)),
+          reopenedPanelIdentifier,
+        );
+        expect(reopenedTrigger.id, initialTriggerId);
+        expect(reopenedPanelIdentifier, initialPanelIdentifier);
+        expect(reopenedPanel.id, isNot(reopenedTrigger.id));
+        expect(_subtreeContainsLabel(reopenedPanel, 'Panel'), isTrue);
 
-      final reopenedTrigger = tester.getSemantics(find.text('Trigger'));
-      final reopenedPanelIdentifier = _controlledIdentifier(reopenedTrigger);
-      final reopenedPanel = _nodeWithIdentifier(
-        tester.getSemantics(find.byType(Scaffold)),
-        reopenedPanelIdentifier,
-      );
-      expect(reopenedPanelIdentifier, isNot(initialPanelIdentifier));
-      expect(reopenedPanel.id, isNot(reopenedTrigger.id));
-      expect(_subtreeContainsLabel(reopenedPanel, 'Panel'), isTrue);
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
 
-      await tester.tap(find.text('Trigger'));
-      await tester.pump();
-      await tester.tap(find.text('Trigger'));
-      await tester.pump();
-      expect(
-        tester
-            .getSemantics(find.text('Trigger'))
-            .getSemanticsData()
-            .controlsNodes,
-        isNull,
-      );
-      await tester.pump();
-
-      final secondReopenedTrigger = tester.getSemantics(find.text('Trigger'));
-      final secondReopenedIdentifier = _controlledIdentifier(
-        secondReopenedTrigger,
-      );
-      final secondReopenedPanel = _nodeWithIdentifier(
-        tester.getSemantics(find.byType(Scaffold)),
-        secondReopenedIdentifier,
-      );
-      expect(secondReopenedIdentifier, isNot(reopenedPanelIdentifier));
-      expect(secondReopenedPanel.id, isNot(secondReopenedTrigger.id));
-      expect(_subtreeContainsLabel(secondReopenedPanel, 'Panel'), isTrue);
-      handle.dispose();
-    });
+        final secondReopenedTrigger = tester.getSemantics(find.text('Trigger'));
+        final secondReopenedIdentifier = _controlledIdentifier(
+          secondReopenedTrigger,
+        );
+        final secondReopenedPanel = _nodeWithIdentifier(
+          tester.getSemantics(find.byType(Scaffold)),
+          secondReopenedIdentifier,
+        );
+        expect(secondReopenedTrigger.id, initialTriggerId);
+        expect(secondReopenedIdentifier, initialPanelIdentifier);
+        expect(secondReopenedPanel.id, isNot(secondReopenedTrigger.id));
+        expect(_subtreeContainsLabel(secondReopenedPanel, 'Panel'), isTrue);
+        handle.dispose();
+      },
+      skip: kIsWeb,
+    );
 
     testWidgets(
-      'defers and refreshes a controlled relationship when its target remounts',
+      'keeps controlled native semantics identity stable after a remount',
       (tester) async {
         final handle = tester.ensureSemantics();
         var expanded = true;
@@ -153,9 +142,11 @@ void main() {
           ),
         );
 
-        final initialIdentifier = _controlledIdentifier(
-          tester.getSemantics(find.text('Controlled trigger')),
+        final initialTrigger = tester.getSemantics(
+          find.text('Controlled trigger'),
         );
+        final initialTriggerId = initialTrigger.id;
+        final initialIdentifier = _controlledIdentifier(initialTrigger);
 
         rebuild(() => expanded = false);
         await tester.pump();
@@ -169,19 +160,13 @@ void main() {
 
         rebuild(() => expanded = true);
         await tester.pump();
-        expect(
-          tester
-              .getSemantics(find.text('Controlled trigger'))
-              .getSemanticsData()
-              .controlsNodes,
-          isNull,
+        final reopenedTrigger = tester.getSemantics(
+          find.text('Controlled trigger'),
         );
-        await tester.pump();
-        final reopenedIdentifier = _controlledIdentifier(
-          tester.getSemantics(find.text('Controlled trigger')),
-        );
+        final reopenedIdentifier = _controlledIdentifier(reopenedTrigger);
 
-        expect(reopenedIdentifier, isNot(initialIdentifier));
+        expect(reopenedTrigger.id, initialTriggerId);
+        expect(reopenedIdentifier, initialIdentifier);
         final reopenedPanel = _nodeWithIdentifier(
           tester.getSemantics(find.byType(Scaffold)),
           reopenedIdentifier,
@@ -192,6 +177,7 @@ void main() {
         );
         handle.dispose();
       },
+      skip: kIsWeb,
     );
 
     testWidgets('uses unique panel identifiers for multiple disclosures', (

--- a/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
+++ b/packages/naked_ui/test/semantics/naked_disclosure_semantics_test.dart
@@ -12,6 +12,34 @@ int _accessibleLabelCount(WidgetTester tester, String label) => tester.semantics
     .where((node) => node.getSemanticsData().label == label)
     .length;
 
+String _controlledIdentifier(SemanticsNode trigger) {
+  final controlsNodes = trigger.getSemanticsData().controlsNodes;
+  expect(controlsNodes, hasLength(1));
+  return controlsNodes!.single;
+}
+
+SemanticsNode _nodeWithIdentifier(SemanticsNode root, String identifier) {
+  final matches = collectSemanticsNodes(
+    root,
+    (node) => node.getSemanticsData().identifier == identifier,
+    includeMerged: true,
+  );
+  expect(
+    matches,
+    hasLength(1),
+    reason: 'Expected exactly one semantics node with identifier $identifier.',
+  );
+  return matches.single;
+}
+
+bool _subtreeContainsLabel(SemanticsNode root, String label) {
+  final matchingNode = findSemanticsNode(
+    root,
+    (node) => node.getSemanticsData().label.contains(label),
+  );
+  return matchingNode != null;
+}
+
 void main() {
   Widget buildApp(Widget child) => MaterialApp(
     home: Scaffold(body: Center(child: child)),
@@ -30,15 +58,15 @@ void main() {
         ),
       );
 
-      final expandedTrigger = tester
-          .getSemantics(find.text('Trigger'))
-          .getSemanticsData();
-      final initialPanelIdentifier = tester
-          .getSemantics(find.text('Panel'))
-          .getSemanticsData()
-          .identifier;
+      final expandedTrigger = tester.getSemantics(find.text('Trigger'));
+      final initialPanelIdentifier = _controlledIdentifier(expandedTrigger);
+      final initialPanel = _nodeWithIdentifier(
+        tester.getSemantics(find.byType(Scaffold)),
+        initialPanelIdentifier,
+      );
       expect(initialPanelIdentifier, isNotEmpty);
-      expect(expandedTrigger.controlsNodes, {initialPanelIdentifier});
+      expect(initialPanel.id, isNot(expandedTrigger.id));
+      expect(_subtreeContainsLabel(initialPanel, 'Panel'), isTrue);
 
       await tester.tap(find.text('Trigger'));
       await tester.pump();
@@ -55,18 +83,15 @@ void main() {
       await tester.tap(find.text('Trigger'));
       await tester.pump();
 
-      final reopenedPanelIdentifier = tester
-          .getSemantics(find.text('Panel'))
-          .getSemanticsData()
-          .identifier;
-      expect(reopenedPanelIdentifier, initialPanelIdentifier);
-      expect(
-        tester
-            .getSemantics(find.text('Trigger'))
-            .getSemanticsData()
-            .controlsNodes,
-        {reopenedPanelIdentifier},
+      final reopenedTrigger = tester.getSemantics(find.text('Trigger'));
+      final reopenedPanelIdentifier = _controlledIdentifier(reopenedTrigger);
+      final reopenedPanel = _nodeWithIdentifier(
+        tester.getSemantics(find.byType(Scaffold)),
+        reopenedPanelIdentifier,
       );
+      expect(reopenedPanelIdentifier, initialPanelIdentifier);
+      expect(reopenedPanel.id, isNot(reopenedTrigger.id));
+      expect(_subtreeContainsLabel(reopenedPanel, 'Panel'), isTrue);
       handle.dispose();
     });
 
@@ -93,30 +118,97 @@ void main() {
         ),
       );
 
-      final firstPanelIdentifier = tester
-          .getSemantics(find.text('First panel'))
-          .getSemanticsData()
-          .identifier;
-      final secondPanelIdentifier = tester
-          .getSemantics(find.text('Second panel'))
-          .getSemanticsData()
-          .identifier;
+      final firstTrigger = tester.getSemantics(find.text('First trigger'));
+      final secondTrigger = tester.getSemantics(find.text('Second trigger'));
+      final firstPanelIdentifier = _controlledIdentifier(firstTrigger);
+      final secondPanelIdentifier = _controlledIdentifier(secondTrigger);
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final firstPanel = _nodeWithIdentifier(root, firstPanelIdentifier);
+      final secondPanel = _nodeWithIdentifier(root, secondPanelIdentifier);
       expect(firstPanelIdentifier, isNotEmpty);
       expect(secondPanelIdentifier, isNotEmpty);
       expect(firstPanelIdentifier, isNot(secondPanelIdentifier));
+      expect(firstPanel.id, isNot(firstTrigger.id));
+      expect(secondPanel.id, isNot(secondTrigger.id));
+      expect(_subtreeContainsLabel(firstPanel, 'First panel'), isTrue);
+      expect(_subtreeContainsLabel(secondPanel, 'Second panel'), isTrue);
+      handle.dispose();
+    });
+
+    testWidgets('controls a distinct panel beneath a semantics container', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          Semantics(
+            container: true,
+            label: 'Outer container',
+            child: const NakedDisclosure(
+              defaultExpanded: true,
+              child: Text('Nested trigger'),
+              panel: Text('Nested panel'),
+            ),
+          ),
+        ),
+      );
+
+      final trigger = tester.getSemantics(find.text('Nested trigger'));
+      final panel = _nodeWithIdentifier(
+        tester.getSemantics(find.byType(Scaffold)),
+        _controlledIdentifier(trigger),
+      );
+
+      expect(panel.id, isNot(trigger.id));
+      expect(_subtreeContainsLabel(panel, 'Nested panel'), isTrue);
+      expect(_subtreeContainsLabel(panel, 'Nested trigger'), isFalse);
+      handle.dispose();
+    });
+
+    testWidgets('preserves consumer semantics within the controlled panel', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildApp(
+          NakedDisclosure(
+            defaultExpanded: true,
+            child: const Text('Trigger'),
+            panel: Column(
+              children: [
+                Semantics(
+                  identifier: 'consumer-panel-id',
+                  child: const Text('Consumer panel'),
+                ),
+                TextButton(onPressed: () {}, child: const Text('Panel action')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final trigger = tester.getSemantics(find.text('Trigger'));
+      final relationshipIdentifier = _controlledIdentifier(trigger);
+      final root = tester.getSemantics(find.byType(Scaffold));
+      final relationshipTarget = _nodeWithIdentifier(
+        root,
+        relationshipIdentifier,
+      );
+      final consumerNode = _nodeWithIdentifier(root, 'consumer-panel-id');
+
+      expect(relationshipIdentifier, isNot('consumer-panel-id'));
+      expect(relationshipTarget.id, isNot(trigger.id));
+      expect(consumerNode.id, isNot(relationshipTarget.id));
       expect(
-        tester
-            .getSemantics(find.text('First trigger'))
-            .getSemanticsData()
-            .controlsNodes,
-        {firstPanelIdentifier},
+        _subtreeContainsLabel(relationshipTarget, 'Consumer panel'),
+        isTrue,
       );
       expect(
         tester
-            .getSemantics(find.text('Second trigger'))
+            .getSemantics(find.text('Panel action'))
             .getSemanticsData()
-            .controlsNodes,
-        {secondPanelIdentifier},
+            .hasAction(SemanticsAction.tap),
+        isTrue,
       );
       handle.dispose();
     });

--- a/packages/naked_ui/test/src/naked_disclosure_test.dart
+++ b/packages/naked_ui/test/src/naked_disclosure_test.dart
@@ -231,6 +231,40 @@ void main() {
       semantics.dispose();
     });
 
+    testWidgets('semantics refresh preserves stateful trigger identity', (
+      tester,
+    ) async {
+      var initialized = 0;
+      var disposed = 0;
+      await tester.pumpMaterialWidget(
+        NakedDisclosure(
+          child: _TriggerLifecycleProbe(
+            onInitialized: () => initialized += 1,
+            onDisposed: () => disposed += 1,
+          ),
+          panel: const Text('Panel'),
+        ),
+      );
+
+      tester
+          .state<_TriggerLifecycleProbeState>(
+            find.byType(_TriggerLifecycleProbe),
+          )
+          .increment();
+      await tester.pump();
+      expect(find.text('Trigger 1'), findsOneWidget);
+
+      await tester.tap(find.text('Trigger 1'));
+      await tester.pump();
+      await tester.tap(find.text('Trigger 1'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Trigger 1'), findsOneWidget);
+      expect(initialized, 1);
+      expect(disposed, 0);
+    });
+
     testWidgets('keyboard press feedback lasts 100ms', (tester) async {
       late NakedDisclosureState state;
       final changes = <bool>[];
@@ -812,4 +846,38 @@ class _PanelLifecycleProbeState extends State<_PanelLifecycleProbe> {
       child: Text('Panel $_value'),
     );
   }
+}
+
+class _TriggerLifecycleProbe extends StatefulWidget {
+  const _TriggerLifecycleProbe({
+    required this.onInitialized,
+    required this.onDisposed,
+  });
+
+  final VoidCallback onInitialized;
+  final VoidCallback onDisposed;
+
+  @override
+  State<_TriggerLifecycleProbe> createState() => _TriggerLifecycleProbeState();
+}
+
+class _TriggerLifecycleProbeState extends State<_TriggerLifecycleProbe> {
+  var _value = 0;
+
+  void increment() => setState(() => _value += 1);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onInitialized();
+  }
+
+  @override
+  void dispose() {
+    widget.onDisposed();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Text('Trigger $_value');
 }


### PR DESCRIPTION
## Description\n\nNakedDisclosure currently exposes expanded state but not the semantic relationship between its trigger and panel. This change gives each disclosure state a private, stable panel identifier and sets the trigger controlsNodes relationship only while expanded, matching the panel presence in the semantics tree.\n\nAfter reopening, the relationship is deferred until the remounted panel has registered in the semantics tree. This makes Flutter web resolve aria-controls to the recreated DOM semantics node instead of retaining a stale target or dropping the relationship because the target was not ready.\n\nNo public API is added or changed. Visible-label derivation, explicit label replacement, disabled behavior, keyboard interaction, focus restoration, and animated closing remain unchanged.\n\nThe disclosure accessibility documentation now describes the relationship lifecycle.\n\n## Related Issues\n\nNone. This is an upstream prerequisite for the Remix Disclosure integration.\n\n---\n\n## Checklist\n\n- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors.\n- [x] I have updated or added relevant documentation.\n- [x] I am prepared to follow up on review comments in a timely manner.\n\n## Breaking Change\n\n- [ ] Yes, this is a breaking change.\n- [x] No, this is not a breaking change.\n\n## Verification\n\n- dart format --set-exit-if-changed .\n- flutter analyze\n- flutter test packages/naked_ui/test\n- flutter test packages/example/test\n- flutter pub publish --dry-run (0 warnings)\n- Remix Widgetbook on Flutter web using this branch: initial aria-controls target exists, Enter collapse removes the relationship, and Space reopen resolves to the recreated panel.