### PR TITLE
chore(release): prepare 1.0.0-beta.14

### DIFF
--- a/packages/naked_ui/CHANGELOG.md
+++ b/packages/naked_ui/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-beta.14
+
+### Fixes
+
+- Link each `NakedDisclosure` trigger to its controlled panel in the semantics
+  tree. Web relationships now resolve to the current panel DOM node after
+  repeated remounts, while native trigger identity and the panel identifier
+  remain stable.
+
 ## 1.0.0-beta.13
 
 ### Features

--- a/packages/naked_ui/pubspec.yaml
+++ b/packages/naked_ui/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/conceptadev/naked_ui
 documentation: https://docs.page/conceptadev/naked_ui
 issue_tracker: https://github.com/conceptadev/naked_ui/issues
 license: BSD-3-Clause
-version: 1.0.0-beta.13
+version: 1.0.0-beta.14
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## What

Cuts `1.0.0-beta.14`: adds the release changelog section and bumps `packages/naked_ui/pubspec.yaml`.

## Contents

One fix PR landed since `1.0.0-beta.13`:

- #97 — links each `NakedDisclosure` trigger to its controlled panel, refreshes the generated Web `aria-controls` target across repeated panel remounts, and preserves stable native semantics identity.

## Verification

- `dart run melos run format:check`
- `flutter analyze`
- Package tests: 750 passed, 3 expected skips
- Example tests: 26 passed, 3 expected skips
- `flutter pub publish --dry-run --directory packages/naked_ui`: 0 warnings

## After merge

Publishing is tag-driven. Tag the merged `main` commit as `v1.0.0-beta.14` to trigger the release workflow and pub.dev publication.